### PR TITLE
Completes User Story 1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,12 @@
             "always"
         ],
         "no-multi-spaces": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            {
+                "max": 1
+            }
+        ],
         "no-return-await": "error",
         "quotes": [
             "error",

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+.local-history

--- a/package.json
+++ b/package.json
@@ -24,8 +24,20 @@
             {
                 "command": "local-history.echo",
                 "title": "Local History"
+            },
+            {
+                "command": "local-history.viewAllForActiveEditor",
+                "title": "Local History: Active Editor"
             }
-        ]
+        ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "local-history.viewAllForActiveEditor",
+                    "when": "editorTextFocus"
+                }
+            ]
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,27 @@
 import * as vscode from 'vscode';
+import { LocalHistoryProvider } from './local-history';
 
 export function activate(context: vscode.ExtensionContext) {
+    const provider = new LocalHistoryProvider();
+
     let disposable = vscode.commands.registerCommand('local-history.echo', () => {
         vscode.window.showInformationMessage('\'Local History\' is active.');
     });
     context.subscriptions.push(disposable);
+
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('local-history.viewAllForActiveEditor',
+        () => {
+            const editor = vscode.window.activeTextEditor;
+            if (editor) {
+                provider.viewAllForActiveEditor(editor);
+            }
+        }
+    ));
+
+    // Create history on save document
+    vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
+        provider.saveActiveEditorContext(document);
+    });
 }
 
 export function deactivate() { }

--- a/src/local-history.ts
+++ b/src/local-history.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode';
+import path = require('path');
+import fs = require('fs');
+
+export interface HistoryFileProperties {
+    fileName: string;
+    timeStamp: string;
+    uri: string;
+    parentFileName: string;
+}
+
+export class LocalHistoryProvider {
+
+    private historyFiles: any[] = [];
+
+    /**
+     * View all history of the active editor
+     */
+    public viewAllForActiveEditor(textEditor: vscode.TextEditor): void {
+
+        if (vscode.workspace.getWorkspaceFolder(textEditor.document.uri) !== undefined) {
+            const workspaceFolderPath: string = vscode.workspace.getWorkspaceFolder(textEditor.document.uri)!.uri.fsPath;
+            const activeEditor = path.parse(textEditor.document.fileName);
+
+            const items: vscode.QuickPickItem[] = this.historyFiles.
+                filter(item => item.parentFileName === (activeEditor.base)).
+                map(item => ({
+                    label: item.fileName,
+                    description: item.timeStamp,
+                    detail: vscode.workspace.asRelativePath(item.uri)
+                }));
+
+            if (items.length == 0) {
+                vscode.window.showInformationMessage(`No local history file found for '${activeEditor.base}'`);
+                return;
+            }
+
+            vscode.window.showQuickPick(items,
+                {
+                    placeHolder: 'Please select a file in history to open',
+                    matchOnDescription: true,
+                    matchOnDetail: true
+                }).then((selection) => {
+                    // User made final selection
+                    if (!selection) {
+                        return;
+                    }
+
+                    // get the file system path for the selection
+                    const selectionFsPath = path.join(`${workspaceFolderPath}`, '.local-history', selection.label);
+                    // create the document and show it in the UI
+                    vscode.workspace.openTextDocument(selectionFsPath).then(doc => vscode.window.showTextDocument(doc), err => vscode.window.showInformationMessage(err.message));
+                });
+        }
+        else {
+            vscode.window.showInformationMessage('File does not belong to any workspace folder. Please save.');
+        }
+    }
+
+    /**
+     * Return the timestamp in the following format: 20200406102550_123.ts
+     */
+    private getCurrentTime(toISOString: boolean): string {
+        let time = new Date();
+        time = new Date(time.getTime() - (time.getTimezoneOffset() * 60000));
+        if (toISOString) {
+            return time.toISOString().substring(0, 19).replace(/[T]/g, ' ');
+        }
+        return time.toISOString().substring(0, 23).replace(/[-:T.]/g, '');
+    }
+
+    /**
+     * Save the current context of the active editor
+     */
+    public saveActiveEditorContext(document: vscode.TextDocument): HistoryFileProperties | undefined {
+        // get timestamp
+        const timestamp = this.getCurrentTime(false);
+        // filePath returns an absolute path     // use filePath.dir to get full directory path
+        const fileFullPath = path.parse(document.fileName);
+        const historyFileName = `${fileFullPath.name}_${timestamp.substring(0, 14)}_${timestamp.substring(14, 17)}${fileFullPath.ext}`;
+
+        if (vscode.workspace.getWorkspaceFolder(document.uri) !== undefined) {
+            const workspaceFolderPath: string = vscode.workspace.getWorkspaceFolder(document.uri)!.uri.fsPath;
+
+            const historyFolderPath = path.join(workspaceFolderPath, '.local-history');
+
+            // create .local-history folder if it does not exist
+            if (!fs.existsSync(historyFolderPath)) {
+                fs.mkdirSync(historyFolderPath, { recursive: true });
+            }
+
+            // copy the content of the current active editor
+            const fileBuffer = fs.readFileSync(document.fileName);
+            const historyFilePath = path.join(workspaceFolderPath, '.local-history', historyFileName);
+            fs.writeFileSync(historyFilePath, fileBuffer);
+
+            let data: HistoryFileProperties = {
+                fileName: historyFileName,
+                timeStamp: this.getCurrentTime(true),
+                uri: historyFilePath,
+                parentFileName: fileFullPath.name + fileFullPath.ext
+            };
+
+            this.historyFiles.push(data);
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
Finish: #1 

#### What it does
- create local history quick-pick command, and editor context-item
- save the content of the current editor at the given timestamps
- quick-pick now displays the filename, timestamps and file path of the history files for the current editor
- user can now select an item in the listing and open the older version of file in a new editor
- When user attempts to view local history for an active editor that does not belong to a workspace folder, a message is shown.
- When no local history is available for an active editor, a message is shown.

#### How to test
- Press F5 to run the tests in a new window with your extension loaded.
- Create a new file
- Open the Command Palette (Ctrl+Shift+P), enter `Local History: Local History: Active Editor`
- Right click in the active editor and sellect `Local History: Local History: Active Editor`


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>