### PR TITLE
Load history files on activation and code refactor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,26 +2,42 @@ import * as vscode from 'vscode';
 import { LocalHistoryProvider } from './local-history';
 
 export function activate(context: vscode.ExtensionContext) {
+    const disposable: vscode.Disposable[] = [];
+
+    // Initialize a local history provider and load entries.
     const provider = new LocalHistoryProvider();
+    if (vscode.workspace.workspaceFolders) {
+        provider.loadEntriesOnActivation();
+    }
 
-    let disposable = vscode.commands.registerCommand('local-history.echo', () => {
-        vscode.window.showInformationMessage('\'Local History\' is active.');
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+        vscode.window.showInformationMessage('The workspace has been updated!');
+        if (vscode.workspace.workspaceFolders) {
+            provider.loadEntriesOnActivation();
+        }
     });
-    context.subscriptions.push(disposable);
 
-    context.subscriptions.push(vscode.commands.registerTextEditorCommand('local-history.viewAllForActiveEditor',
-        () => {
+    // Simple command to echo if the extension has successfully loaded and is active.
+    disposable.push(vscode.commands.registerCommand('local-history.echo', () => {
+        vscode.window.showInformationMessage('\'Local History\' is active.');
+    }));
+
+    // Command which lists the local history for the active editor.
+    disposable.push(
+        vscode.commands.registerTextEditorCommand('local-history.viewAllForActiveEditor', () => {
             const editor = vscode.window.activeTextEditor;
             if (editor) {
                 provider.viewAllForActiveEditor(editor);
             }
-        }
-    ));
+        })
+    );
 
-    // Create history on save document
+    // Listen to editor save events to create local history files.
     vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
         provider.saveActiveEditorContext(document);
     });
+
+    context.subscriptions.push(...disposable);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
#### What it does
- Load all local history file entries on activation
- Refactor code for generating timestamp

#### How to test
- Press F5 to run the tests in a new window with your extension loaded.
- Go to `File` on top menu and select `Add Folder to Workspace`
- Select a workspace folder
- Create a new file inside the `src` folder
- Open the Command Palette (Ctrl+Shift+P), enter `Local History: Local History: Active Editor`
- Right click in the active editor and sellect `Local History: Local History: Active Editor`

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>