### PR TITLE
preference: add a preference to control the number of entries of revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,16 @@
                     "when": "editorTextFocus"
                 }
             ]
+        },
+        "configuration": {
+            "title": "Local History",
+            "properties": {
+                "local-history.maxEntriesPerFile": {
+                    "type": "number",
+                    "default": 10,
+                    "description": "Controls the number of entries to keep for a given file"
+                }
+            }
         }
     },
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { LocalHistoryProvider } from './local-history';
+import { LocalHistoryProvider, maxEntriesPerFile } from './local-history';
 
 export function activate(context: vscode.ExtensionContext) {
     const disposable: vscode.Disposable[] = [];
@@ -14,6 +14,12 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage('The workspace has been updated!');
         if (vscode.workspace.workspaceFolders) {
             provider.loadEntriesOnActivation();
+        }
+    });
+
+    vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration(maxEntriesPerFile)) {
+            provider.updateMaxEntriesPerFile();
         }
     });
 


### PR DESCRIPTION
[Preference]: add a preference to control the number of entries to keep for a file

Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/5

Added preference to control the number of revisions to store from the
most recent one, the revisions are not deleted so if at any point the
user tends to change it to a larger number, the older ones will show up.

How to Test: 

- Press F5 to run the tests in a new window with your extension loaded.
- Go to File on top menu and select Add Folder to Workspace
- Select a workspace folder
- Create a new file inside the src folder
- Open file>preferences>settings>extensions>local History
- Change the value of the max file revisions
- Open the Command Palette (Ctrl+Shift+P), enter Local History: Local History: Active Editor

All this process of testing should be done after saving a bunch of times and increasing the max file revisions to see all the previous revisions.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>