### PR TITLE
Revert active editor to its previous state

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
                 "command": "local-history.viewAllForActiveEditor",
                 "title": "Local History: Active Editor",
                 "when": "editorTextFocus"
+            },
+            {
+                "command": "local-history.revertActiveEditorToPrevRevision",
+                "title": "Local History: Revert to Previous Revision",
+                "icon": "$(history)",
+                "when": "editorTextFocus"
             }
         ],
         "menus": {
@@ -32,6 +38,17 @@
                 {
                     "command": "local-history.viewAllForActiveEditor",
                     "when": "editorIsOpen && resourceScheme == file"
+                },
+                {
+                    "command": "local-history.revertActiveEditorToPrevRevision",
+                    "when": "editorIsOpen && resourceScheme == file"
+                }
+            ],
+            "editor/title": [
+                {
+                    "command": "local-history.revertActiveEditorToPrevRevision",
+                    "when": "textCompareEditorVisible && isInDiffEditor",
+                    "group": "navigation"
                 }
             ],
             "editor/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { LocalHistoryManager } from './local-history/local-history-manager';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -13,6 +14,19 @@ export function activate(context: vscode.ExtensionContext) {
         // Displays the local history for the currently active editor.
         vscode.commands.registerTextEditorCommand('local-history.viewAllForActiveEditor', () => {
             provider.viewAllForActiveEditor(vscode.window.activeTextEditor!);
+        })
+    );
+
+    disposable.push(
+        vscode.commands.registerTextEditorCommand('local-history.revertActiveEditorToPrevRevision', () => {
+            const editors = vscode.window.visibleTextEditors;
+            if (editors && editors.length === 2) {
+                vscode.window.showWarningMessage(`Are you sure you want to revert '${path.basename(editors[1].document.fileName)}' to its previous state?`, { modal: true }, 'Revert').then((selection) => {
+                    if (selection === 'Revert') {
+                        provider.revertActiveEditorToPrevRevision(editors[0], editors[1]);
+                    }
+                });
+            }
         })
     );
 

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -167,4 +167,14 @@ export class LocalHistoryManager {
         }
     }
 
+    /**
+     * Revert the current active editor to its previous revision.
+     */
+    public revertActiveEditorToPrevRevision(previous: vscode.TextEditor, current: vscode.TextEditor): void {
+        if (current && previous) {
+            const fileBuffer = fs.readFileSync(previous.document.fileName);
+            fs.writeFileSync(current.document.fileName, fileBuffer);
+        }
+    }
+
 }


### PR DESCRIPTION
#### What it does
- Add a `Clock icon` in the top right menu in diff mode
- When user click the `Clock icon`, Display pop-up message asking the user to confirm the reversion
- If `Revert` is selected, the active editor will be reverted to its previous revision

#### How to test
- Press F5 to run the tests in a new window with your extension loaded.
- Go to `File` on top menu and select `Add Folder to Workspace`
- Select a workspace folder
- Create a new file inside the `src` folder
- Open the Command Palette (Ctrl+Shift+P), enter `Local History: Local History: Active Editor`
- Right click in the active editor to trigger  the editor's context menu and select  `Local History: Active Editor`
- Select a local history file to view the diff
- Click the `Clock icon` in the top right menu when in diff mode


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>