### PR TITLE
Retrieve file uri from selection.description

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -102,7 +102,7 @@ export class LocalHistoryManager {
                     }
 
                     // Get the file system path for the selection.
-                    const selectionFsPath = path.join(`${workspaceFolderPath}`, '.local-history', selection.label);
+                    const selectionFsPath = path.join(`${workspaceFolderPath}`, selection.description!);
 
                     // Show the diff between the active editor and the selected local history file.
                     this.displayDiff(vscode.Uri.file(selectionFsPath), textEditor.document.uri);


### PR DESCRIPTION
Fix: #23 

#### What it does
- When opening a local history file from the quickPick menu, retrieve the file uri from `selection.description`

#### How to test
- Press F5 to run the tests in a new window with your extension loaded.
- Go to `File` on top menu and select `Add Folder to Workspace`
- Select a workspace folder
- Create a new file inside the `src` folder
- Open the Command Palette (Ctrl+Shift+P), enter `Local History: Local History: Active Editor`
- Right click in the active editor to trigger  the editor's context menu and select  `Local History: Active Editor`
- Select a local history file to view the diff

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>