### PR TITLE
[Command]: Command should respect an active/preview editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
             }
         ],
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "local-history.viewAllForActiveEditor",
+                    "when": "editorIsOpen && resourceScheme == file"
+                }
+            ],
             "editor/context": [
                 {
                     "command": "local-history.viewAllForActiveEditor",


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/22

Currently in master, the command `Local History: Active Editor` was
visible for any file opened, and even without any editors opened. Added
functionality to tackle this situation, and handle the command when
there is an editor opened.

How to Test:
1. open a workspace (without any files)
2. press F1 and search for local history
3. see that the command is not available with no editors opened, and available with an editor opened with a file from the filesystem.


Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>