### PR TITLE
Remove a revision through the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,12 @@
                 "title": "Local History: Revert to Previous Revision",
                 "icon": "$(history)",
                 "when": "editorTextFocus"
+            },
+            {
+                "command": "local-history.removeRevision",
+                "title": "Local History: Remove Revision",
+                "icon": "$(trash)",
+                "when": "textCompareEditorVisible && isInDiffEditor"
             }
         ],
         "menus": {
@@ -42,13 +48,22 @@
                 {
                     "command": "local-history.revertActiveEditorToPrevRevision",
                     "when": "editorIsOpen && resourceScheme == file"
+                },
+                {
+                    "command": "local-history.removeRevision",
+                    "when": "editorIsOpen && resourceScheme == file && textCompareEditorVisible && isInDiffEditor"
                 }
             ],
             "editor/title": [
                 {
                     "command": "local-history.revertActiveEditorToPrevRevision",
                     "when": "textCompareEditorVisible && isInDiffEditor",
-                    "group": "navigation"
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "local-history.removeRevision",
+                    "when": "textCompareEditorVisible && isInDiffEditor",
+                    "group": "navigation@2"
                 }
             ],
             "editor/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Command which reverts the active editor to its previous revision.
     disposable.push(
         vscode.commands.registerTextEditorCommand('local-history.revertActiveEditorToPrevRevision', () => {
             const editors = vscode.window.visibleTextEditors;
@@ -26,6 +27,19 @@ export function activate(context: vscode.ExtensionContext) {
                         provider.revertActiveEditorToPrevRevision(editors[0], editors[1]);
                     }
                 });
+            }
+            else if (editors && editors.length === 1) {
+                provider.viewAllForActiveEditor(vscode.window.activeTextEditor!);
+            }
+        })
+    );
+
+    // Command which remove the active revision of a file.
+    disposable.push(
+        vscode.commands.registerTextEditorCommand('local-history.removeRevision', () => {
+            const editors = vscode.window.visibleTextEditors;
+            if (editors && editors.length > 0) {
+                provider.removeRevision(editors[0]);
             }
         })
     );


### PR DESCRIPTION
#### What it does
- Add a  `Trash icon` in diff-mode
- Display pop-up message asking the user to confirm the deletion
- If `Delete` is selected, the current active revision of a file will be deleted
- Fix `File is not a revision` error on Windows

#### How to test
- Press F5 to run the tests in a new window with your extension loaded.
- Go to `File` on top menu and select `Add Folder to Workspace`
- Select a workspace folder
- Create a new file inside the `src` folder
- Open the Command Palette (Ctrl+Shift+P), enter `Local History: Local History: Active Editor`
- Right click in the active editor to trigger  the editor's context menu and select  `Local History: Active Editor`
- Select a local history file to view the diff
- Click the `Trash icon` in the top right menu when in diff mode

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>