### PR TITLE
Save and retrieve local history under the user's home

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "contributes": {
         "commands": [
             {
-                "command": "local-history.viewAllForActiveEditor",
+                "command": "local-history.viewHistory",
                 "title": "Local History: Active Editor",
                 "when": "editorTextFocus"
             },
             {
-                "command": "local-history.revertActiveEditorToPrevRevision",
+                "command": "local-history.revertToPrevRevision",
                 "title": "Local History: Revert to Previous Revision",
                 "icon": "$(history)",
                 "when": "textCompareEditorVisible && isInDiffEditor"
@@ -42,11 +42,11 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "local-history.viewAllForActiveEditor",
+                    "command": "local-history.viewHistory",
                     "when": "editorIsOpen && resourceScheme == file"
                 },
                 {
-                    "command": "local-history.revertActiveEditorToPrevRevision",
+                    "command": "local-history.revertToPrevRevision",
                     "when": "false"
                 },
                 {
@@ -56,7 +56,7 @@
             ],
             "editor/title": [
                 {
-                    "command": "local-history.revertActiveEditorToPrevRevision",
+                    "command": "local-history.revertToPrevRevision",
                     "when": "textCompareEditorVisible && isInDiffEditor",
                     "group": "navigation@1"
                 },
@@ -68,7 +68,7 @@
             ],
             "editor/context": [
                 {
-                    "command": "local-history.viewAllForActiveEditor",
+                    "command": "local-history.viewHistory",
                     "when": "editorTextFocus"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,19 +12,19 @@ export function activate(context: vscode.ExtensionContext) {
 
     disposable.push(
         // Displays the local history for the currently active editor.
-        vscode.commands.registerTextEditorCommand('local-history.viewAllForActiveEditor', () => {
-            provider.viewAllForActiveEditor(vscode.window.activeTextEditor!);
+        vscode.commands.registerTextEditorCommand('local-history.viewHistory', () => {
+            provider.viewHistory(vscode.window.activeTextEditor!);
         })
     );
 
     // Command which reverts the active editor to its previous revision.
     disposable.push(
-        vscode.commands.registerTextEditorCommand('local-history.revertActiveEditorToPrevRevision', () => {
+        vscode.commands.registerTextEditorCommand('local-history.revertToPrevRevision', () => {
             const editors = vscode.window.visibleTextEditors;
             if (editors && editors.length === 2) {
                 vscode.window.showWarningMessage(`Are you sure you want to revert '${path.basename(editors[1].document.fileName)}' to its previous state?`, { modal: true }, 'Revert').then((selection) => {
                     if (selection === 'Revert') {
-                        provider.revertActiveEditorToPrevRevision(editors[0], editors[1]);
+                        provider.revertToPrevRevision(editors[0], editors[1]);
                     }
                 });
             }
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
     disposable.push(
         vscode.commands.registerTextEditorCommand('local-history.removeRevision', () => {
             const editors = vscode.window.visibleTextEditors;
-            if (editors && editors.length > 0) {
+            if (editors && editors.length === 2) {
                 provider.removeRevision(editors[0]);
             }
         })


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/37

**What it does**
Creates a .local-history folder in the home directory of the user,
it then also hashes the file uri and creates folder on each uri.
Currently it is stored in each workspace.

**How to Test**
1. Add a new folder to the workspace
2. Save something on an active editor 
4. Go to your local home directory
5. navigate to .local-history
6. Check to see if there exists a folder name with hashcode
7. Open the folder to see if there are revisions.
8. Open the Command Palette (Ctrl+Shift+P), enter Local History: Local History: Active Editor
9. Right click in the active editor to trigger the editor's context menu and select Local History: Active Editor
10. Select a local history file to view the diff
11. Click the `Trash` icon in the top right menu when in diff mode to delete the revision
12. Click the `Revert` icon in the top right menu when in diff mode to revert to previous revision

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>