### PR TITLE
Remove commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
                 "command": "local-history.revertActiveEditorToPrevRevision",
                 "title": "Local History: Revert to Previous Revision",
                 "icon": "$(history)",
-                "when": "editorTextFocus"
+                "when": "textCompareEditorVisible && isInDiffEditor"
             },
             {
                 "command": "local-history.removeRevision",
@@ -47,11 +47,11 @@
                 },
                 {
                     "command": "local-history.revertActiveEditorToPrevRevision",
-                    "when": "editorIsOpen && resourceScheme == file"
+                    "when": "false"
                 },
                 {
                     "command": "local-history.removeRevision",
-                    "when": "editorIsOpen && resourceScheme == file && textCompareEditorVisible && isInDiffEditor"
+                    "when": "false"
                 }
             ],
             "editor/title": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,9 +28,6 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                 });
             }
-            else if (editors && editors.length === 1) {
-                provider.viewAllForActiveEditor(vscode.window.activeTextEditor!);
-            }
         })
     );
 


### PR DESCRIPTION
**Description**
- Remove `Revert to Previous Revision` and `Remove Revision` from command palette since
1. they do not function properly
2. it is redundant to keep them (they already exist in the navigator in diff mode)

**How to test**
1. Open a file inside a workspace
2. Open the Command Palette (`Revert to Previous Revision` and `Remove Revision` should no longer be there)

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>