### PR TITLE
Clear all local history for the active file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
                 "title": "Local History: Remove Revision",
                 "icon": "$(trash)",
                 "when": "textCompareEditorVisible && isInDiffEditor"
+            },
+            {
+                "command": "local-history.clearHistory",
+                "title": "Local History: Clear History Active File"
             }
         ],
         "menus": {
@@ -52,6 +56,10 @@
                 {
                     "command": "local-history.removeRevision",
                     "when": "false"
+                },
+                {
+                    "command": "local-history.clearHistory",
+                    "when": "editorIsOpen && resourceScheme == file"
                 }
             ],
             "editor/title": [
@@ -70,6 +78,17 @@
                 {
                     "command": "local-history.viewHistory",
                     "when": "editorTextFocus"
+                },
+                {
+                    "command": "local-history.clearHistory",
+                    "when": "editorTextFocus"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "local-history.clearHistory",
+                    "when": "!explorerResourceIsFolder",
+                    "group": "LocalHistory@1"
                 }
             ]
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,13 +31,23 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    // Command which remove the active revision of a file.
+    // Command which removes the active revision of a file.
     disposable.push(
         vscode.commands.registerTextEditorCommand('local-history.removeRevision', () => {
             const editors = vscode.window.visibleTextEditors;
             if (editors && editors.length === 2) {
                 provider.removeRevision(editors[0]);
             }
+        })
+    );
+
+    // Command which removes all revisions of the active file.
+    disposable.push(
+        vscode.commands.registerCommand('local-history.clearHistory', (uri: vscode.Uri) => {
+            if (uri === undefined) {
+                uri = vscode.window.activeTextEditor!.document.uri;
+            }
+            provider.clearHistory(uri);
         })
     );
 


### PR DESCRIPTION
**Description**
- User can now clear the local history for the active editor through
1. the command palette
2. the explorer's context menu
3. editor's context menu

**How to test**
1. Press f5 to enter debug mode
2. Add a folder to the workspace
3. Add content to a file and save it
4. Repeat step 3
5. Clear all local history for the active file using the command palette (when there is an active editor)
6. Clear all local history for the active file using the explorer's context menu
7. Clear all local history for the active editor using the editor's context menu

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>