### PR TITLE
Add `View History` to explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
         "commands": [
             {
                 "command": "local-history.viewHistory",
-                "title": "Local History: Active Editor",
-                "when": "editorTextFocus"
+                "title": "Local History: View History"
             },
             {
                 "command": "local-history.revertToPrevRevision",
@@ -40,7 +39,7 @@
             },
             {
                 "command": "local-history.clearHistory",
-                "title": "Local History: Clear History Active File"
+                "title": "Local History: Clear History"
             }
         ],
         "menus": {
@@ -77,18 +76,25 @@
             "editor/context": [
                 {
                     "command": "local-history.viewHistory",
-                    "when": "editorTextFocus"
+                    "when": "editorTextFocus",
+                    "group": "LocalHistory@1"
                 },
                 {
                     "command": "local-history.clearHistory",
-                    "when": "editorTextFocus"
+                    "when": "editorTextFocus",
+                    "group": "LocalHistory@2"
                 }
             ],
             "explorer/context": [
                 {
-                    "command": "local-history.clearHistory",
+                    "command": "local-history.viewHistory",
                     "when": "!explorerResourceIsFolder",
                     "group": "LocalHistory@1"
+                },
+                {
+                    "command": "local-history.clearHistory",
+                    "when": "!explorerResourceIsFolder",
+                    "group": "LocalHistory@2"
                 }
             ]
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,13 @@ export function activate(context: vscode.ExtensionContext) {
     const provider: LocalHistoryManager = new LocalHistoryManager();
 
     disposable.push(
-        // Displays the local history for the currently active editor.
-        vscode.commands.registerTextEditorCommand('local-history.viewHistory', () => {
-            provider.viewHistory(vscode.window.activeTextEditor!);
+        // Displays the local history of the active file.
+        vscode.commands.registerCommand('local-history.viewHistory', (uri: vscode.Uri) => {
+            if (uri === undefined) {
+                uri = vscode.window.activeTextEditor!.document.uri;
+            }
+            provider.viewHistory(uri);
+
         })
     );
 

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -74,12 +74,11 @@ export class LocalHistoryManager {
     }
 
     /**
-     * View all history of the active editor.
+     * View all local history of the active file.
      */
-    public viewHistory(editor: vscode.TextEditor): void {
-
-        if (vscode.workspace.getWorkspaceFolder(editor.document.uri) !== undefined) {
-            const hashedEditorPath = checksum(editor.document.fileName);
+    public viewHistory(uri: vscode.Uri): void {
+        if (uri) {
+            const hashedEditorPath = checksum(uri.fsPath);
             const hashedFolderPath = path.join(os.homedir(), '.local-history', hashedEditorPath);
 
             this.loadHistory(hashedFolderPath).then(() => {
@@ -89,7 +88,7 @@ export class LocalHistoryManager {
                 }));
 
                 if (items.length === 0) {
-                    vscode.window.showInformationMessage(`No local history file found for '${path.basename(editor.document.fileName)}'`);
+                    vscode.window.showInformationMessage(`No local history file found for '${path.basename(uri.fsPath)}'`);
                     return;
                 }
 
@@ -97,7 +96,7 @@ export class LocalHistoryManager {
                 items = items.slice(0, this.localHistoryPreferenceService.maxEntriesPerFile);
                 vscode.window.showQuickPick(items,
                     {
-                        placeHolder: `Please select a local history revision for '${path.basename(editor.document.fileName)}'`,
+                        placeHolder: `Please select a local history revision for '${path.basename(uri.fsPath)}'`,
                         matchOnDescription: true,
                         matchOnDetail: true
                     }).then((selection) => {
@@ -109,13 +108,10 @@ export class LocalHistoryManager {
                         // Get the file system path for the selection.
                         const selectionFsPath = path.join(hashedFolderPath, selection.description!);
 
-                        // Show the diff between the active editor and the selected local history file.
-                        this.displayDiff(vscode.Uri.file(selectionFsPath), editor.document.uri);
+                        // Show the diff between the active file and the selected local history file.
+                        this.displayDiff(vscode.Uri.file(selectionFsPath), uri);
                     });
             });
-        }
-        else {
-            vscode.window.showInformationMessage('File does not belong to a workspace. Please save.');
         }
     }
 


### PR DESCRIPTION
**Description**
- Add explorer context menu to trigger history for selected file
- Update title for `View History` and `Clear History`

**How to test**
**_- When there is no active editor:_**
1. Open a workspace
2. Right click on a file in the explorer
3. Select `Local History: View History` in the explorer context menu
4. Open the command and search for `Local History: View History` (**should not exist**)

**_- When there is an active editor:_**
1. Open a workspace
2. Right click on a file in the explorer
3. Select `Local History: View History` in the explorer context menu
4. Open the command and search for `Local History: View History`
5. Right click on the active editor to trigger the editor context menu and select `Local History: View History`


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>