### PR TITLE
Hide 'Revert' and 'Remove revision' icons in split view

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
             "editor/title": [
                 {
                     "command": "local-history.revertToPrevRevision",
-                    "when": "textCompareEditorVisible && isInDiffEditor",
+                    "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
                     "group": "navigation@1"
                 },
                 {
                     "command": "local-history.removeRevision",
-                    "when": "textCompareEditorVisible && isInDiffEditor",
+                    "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
                     "group": "navigation@2"
                 }
             ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,11 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerTextEditorCommand('local-history.removeRevision', () => {
             const editors = vscode.window.visibleTextEditors;
             if (editors && editors.length === 2) {
-                provider.removeRevision(editors[0]);
+                vscode.window.showWarningMessage(`Are you sure you want to delete '${path.basename(editors[0].document.fileName)}' permanently?`, { modal: true }, 'Delete').then((selection) => {
+                    if (selection === 'Delete') {
+                        provider.removeRevision(editors[0]);
+                    }
+                });
             }
         })
     );

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -209,19 +209,14 @@ export class LocalHistoryManager {
      */
     public removeRevision(revision: vscode.TextEditor): void {
         if (revision) {
-            vscode.window.showWarningMessage(`Are you sure you want to delete '${path.basename(revision.document.fileName)}' permanently?`, { modal: true }, 'Delete').then((selection) => {
-                if (selection === 'Delete') {
-
-                    // Remove the revision.
-                    fs.unlink(revision.document.fileName, (err) => {
-                        if (err) {
-                            console.warn('An error has occurred when removing the revision', err.message);
-                            return;
-                        }
-                        vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-                        vscode.window.showInformationMessage(`'${path.basename(revision.document.fileName)}' was deleted.`);
-                    });
+            // Remove the revision.
+            fs.unlink(revision.document.fileName, (err) => {
+                if (err) {
+                    console.warn('An error has occurred when removing the revision', err.message);
+                    return;
                 }
+                vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+                vscode.window.showInformationMessage(`'${path.basename(revision.document.fileName)}' was deleted.`);
             });
         }
     }


### PR DESCRIPTION
**Description**
- Hide the `Revert` and `Remove revision` icons in split view
**In split view:**
![split view](https://user-images.githubusercontent.com/23107734/81096175-036e6980-8ed4-11ea-9281-ccfaf533ce46.JPG)
**Not in split view:**
![no split](https://user-images.githubusercontent.com/23107734/81096166-ff424c00-8ed3-11ea-9db0-06db8f0cd9e0.JPG)

- Refactor code for remove revision for consistency


**How to test**
- Select a workspace folder
- Makes changes to a file
- Right click in the active editor to trigger  the editor's context menu and select  `Local History: Active Editor`
- Select a local history file to view the diff (**should see the two icons**)
- Open another editor in split view (**should no longer see the two icons**)


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>