### PR TITLE
preference: control save delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
                     "type": "number",
                     "default": 10,
                     "description": "Controls the number of entries to keep for a given file"
+                },
+                "local-history.autoSaveDelay": {
+                    "type": "number",
+                    "default": 5000,
+                    "description": "Controls delay in auto saving of local history in milliseconds."
                 }
             }
         }

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -140,11 +140,11 @@ export class LocalHistoryManager {
             const historyFilePath = path.join(hashedFolderPath, historyFileName);
             // Copy the content of the current active editor.
             const activeDocumentContent: string = await this.readFile(document.fileName);
-            const recentRevision = this.getMostRecentRevision(hashedFolderPath);
-            if (recentRevision) {
-                const latestEditorHistoryContent: string | undefined = recentRevision && await this.readFile(recentRevision);
+            const recentUpdatedFile = this.getMostRecentRevision(hashedFolderPath);
+            if (recentUpdatedFile) {
+                const latestEditorHistoryContent: string | undefined = recentUpdatedFile && await this.readFile(recentUpdatedFile);
                 if (latestEditorHistoryContent && activeDocumentContent === latestEditorHistoryContent) {
-                    fs.renameSync(recentRevision, historyFilePath);
+                    fs.renameSync(recentUpdatedFile, historyFilePath);
                     await this.writeFile(historyFilePath, activeDocumentContent);
                     return;
                 }

--- a/src/local-history/local-history-preference-service.ts
+++ b/src/local-history/local-history-preference-service.ts
@@ -8,6 +8,11 @@ export namespace LocalHistoryPreferences {
      * Controls the maximum number of entries of a file for display purposes.
      */
     export const maxEntriesPerFile = 'local-history.maxEntriesPerFile';
+
+    /**
+     * Controls the allowed delay for autosaving a local history file.
+     */
+    export const autoSaveDelay = 'local-history.autoSaveDelay';
 }
 
 export class LocalHistoryPreferenceService {
@@ -17,18 +22,43 @@ export class LocalHistoryPreferenceService {
      */
     private _maxEntriesPerFile: number = 10;
 
+    /**
+     * The delay for automatically saving a history
+     */
+    private _autoSaveDelay: number = 5000;
+
     constructor() {
         // Set the maximum number of entries for a given file.
         this.maxEntriesPerFile = this.getMaxEntriesPerFile();
+        // Sets the auto save delay for a given file
+        this.autoSaveDelay = this.getAutoSaveDelay();
         // Listen for changes to the preference configuration.
         vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
             // If we determine that the preference has been updated, update the max to the new value.
             if (event.affectsConfiguration(LocalHistoryPreferences.maxEntriesPerFile)) {
                 this.maxEntriesPerFile = this.getMaxEntriesPerFile();
             }
+            // If we determine that the preference has been updated, update the delay to the new value.
+            if (event.affectsConfiguration(LocalHistoryPreferences.autoSaveDelay)) {
+                this.autoSaveDelay = this.getAutoSaveDelay();
+            }
         });
     }
 
+    /**
+     * Gets the allowed delay for auto saving a local history
+     */
+    get autoSaveDelay(): number {
+        return this._autoSaveDelay;
+    }
+
+    /**
+     * Sets the allowed delay for auto saving a local history
+     * @param delay the allowed delay in ms for autosaving.
+     */
+    set autoSaveDelay(delay: number) {
+        this._autoSaveDelay = delay;
+    }
     /**
      * Get the maximum allowed local history entries for a file.
      */
@@ -53,4 +83,12 @@ export class LocalHistoryPreferenceService {
         return vscode.workspace.getConfiguration().get(LocalHistoryPreferences.maxEntriesPerFile) as number;
     }
 
+    /**
+     * Gets the allowed delay for autosaving a local history file based on the preference configuration
+     * 
+     * @returns the allowed delay for local history files.
+     */
+    private getAutoSaveDelay(): number {
+        return vscode.workspace.getConfiguration().get(LocalHistoryPreferences.autoSaveDelay) as number;
+    }
 }


### PR DESCRIPTION
Fixes: #9 

**What it does**
Works like autoSave, but for local history, after a specified interval of time, it autosaves the history file of the code. 

**How to Test**
1. Open  a workspace
2. Go to Settings > Preferences > Local History > autoSave
3. Set a value. 
4. Make changes in your file and after every interval, it will create a new history of changes in the files are found. 