### PR TITLE
Add relative modified time using momentJs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,11 @@
 				}
 			}
 		},
+		"moment": {
+			"version": "2.25.3",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+			"integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
         "tslint": "^5.20.0",
         "typescript": "^3.6.4",
         "vscode-test": "^1.2.2"
+    },
+    "dependencies": {
+        "moment": "^2.25.3"
     }
 }

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { LocalHistoryPreferenceService } from './local-history-preference-service';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import * as moment from 'moment';
 
 function checksum(str: string, algorithm: string = 'md5') {
     return crypto
@@ -85,7 +86,8 @@ export class LocalHistoryManager {
             this.loadHistory(hashedFolderPath).then(() => {
                 let items: vscode.QuickPickItem[] = this.historyFilesForActiveEditor.map(item => ({
                     label: `$(calendar) ${item.timestamp}`,
-                    description: path.basename(item.uri)
+                    description: path.basename(item.uri),
+                    detail: `Created ${moment(fs.statSync(uri.fsPath).ctimeMs).fromNow()}`
                 }));
 
                 if (items.length === 0) {
@@ -98,8 +100,7 @@ export class LocalHistoryManager {
                 vscode.window.showQuickPick(items,
                     {
                         placeHolder: `Please select a local history revision for '${path.basename(uri.fsPath)}'`,
-                        matchOnDescription: true,
-                        matchOnDetail: true
+                        matchOnDescription: true
                     }).then((selection) => {
                         // User made final selection.
                         if (!selection) {


### PR DESCRIPTION
**Description**
- Add relative modified time for entries in quickPick menu using momentJs

**How to test**
1. Open a file which does not contain any local-history (clear history if required - ex: rm -rf ~/.local-history)
2. Make a change and perform a save
3. Execute the command Local History: View History (should see the `last modified time`)

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>