### PR TITLE
save history when file is closed.

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -34,6 +34,10 @@ export class LocalHistoryManager {
         vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
             this.checkPermission(event.document);
         });
+
+        vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
+            this.saveEditorContext(document);
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/62

**What it does**
Saves the file history when the file is closed to prevent loss of
content.

**How to Test**
1. Open a workspace
2. Create a new file.
3. Make changes to the file.
4. Save and close the file check to see if local history timestamp is updated on close or not.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>