### PR TITLE
Fix relative modification time bug

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -87,7 +87,7 @@ export class LocalHistoryManager {
                 let items: vscode.QuickPickItem[] = this.historyFilesForActiveEditor.map(item => ({
                     label: `$(calendar) ${item.timestamp}`,
                     description: path.basename(item.uri),
-                    detail: `Created ${moment(fs.statSync(item.uri).birthtime).fromNow()}`
+                    detail: `Last modified ${moment(item.timestamp.replace(/[-: ]/g, ''), 'YYYYMMDDhhmmss').fromNow()}`
                 }));
 
                 if (items.length === 0) {


### PR DESCRIPTION
**Description**
- Fix relative creation time bug when the timestamp of a revision is updated

**How to test**
1. Open a workspace
2. Create a new file.
3. Make changes to the file and save.
4. Save again without changing the content of the file
5. The timestamp should be updated and the relative creation time should now be correct

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>