### PR TITLE
Command to remove histories after x amount of days

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
             {
                 "command": "local-history.clearHistory",
                 "title": "Local History: Clear History"
+            },
+            {
+                "command": "local-history.clearOldHistory",
+                "title": "Local History: Clear Old History"
             }
         ],
         "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,23 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Command which removes old revisions.
+    disposable.push(
+        vscode.commands.registerCommand('local-history.clearOldHistory', async () => {
+            const days = await vscode.window.showInputBox({
+                value: '30',
+                placeHolder: 'Please enter the amount of days',
+                validateInput: input => {
+                    const day = parseInt(input);
+                    return day ? undefined : 'Please enter a valid positive number';
+                }
+            });
+            if (days) {
+                provider.removeOldFiles(parseInt(days));
+            }
+        })
+    );
+
     context.subscriptions.push(...disposable);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/59

**What It Does**
Clears the history which is last modified in X day, where X is decided
by the user input. This helps in clean up of the files.

**How To Test**
Prerequisite: For this PR, you need to have older modified local history files to test, else in order to test, you can reduce the variable value `dayToMilliSeconds` in order to fit your need. (you can change it to `1000` just so it could be converted into seconds, would be easier to test. )

1. Press `f1` and `Local History: Clear Old History`
2. Enter the number of days for which you want history to be deleted
3. Press enter, check to see if the history is successfully deleted inside the `.local-history` folder.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>