### PR TITLE
preference: limit the number of revisions to store for a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,12 @@
                     "type": "number",
                     "default": 25,
                     "description": "Controls the maximum acceptable file size for storing revisions in megabytes."
+                },
+                "local-history.fileLimit": {
+                    "type": "number",
+                    "default": 30,
+                    "minimum": 1,
+                    "description": "Controls the maximum number of saved revisions allowed for a given file"
                 }
             }
         }

--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -1,16 +1,18 @@
 import * as vscode from 'vscode';
-import { MAX_ENTRIES_PER_FILE, SAVE_DELAY, FILE_SIZE_LIMIT } from './local-history-preferences';
+import { MAX_ENTRIES_PER_FILE, SAVE_DELAY, FILE_LIMIT, FILE_SIZE_LIMIT } from './local-history-preferences';
 
 export class LocalHistoryPreferencesService {
 
     private _maxEntriesPerFile: number = MAX_ENTRIES_PER_FILE.default;
     private _saveDelay: number = SAVE_DELAY.default;
     private _fileSizeLimit: number = FILE_SIZE_LIMIT.default;
+    private _fileLimit: number = FILE_LIMIT.default;
 
     constructor() {
         this.maxEntriesPerFile = this.getMaxEntriesPerFile();
         this.saveDelay = this.getSaveDelay();
         this.fileSizeLimit = this.getFileSizeLimit();
+        this.fileLimit = this.getFileLimit();
 
         // Listen to changes to the preferences configuration and update accordingly.
         vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
@@ -22,6 +24,9 @@ export class LocalHistoryPreferencesService {
             }
             if (event.affectsConfiguration(FILE_SIZE_LIMIT.id)) {
                 this.fileSizeLimit = this.getFileSizeLimit();
+            }
+            if (event.affectsConfiguration(FILE_LIMIT.id)) {
+                this.fileLimit = this.getFileLimit();
             }
         });
     }
@@ -75,6 +80,22 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
+     * Get the revision limit for a file.
+     * @returns the file limit.
+     */
+    get fileLimit(): number {
+        return this._fileLimit;
+    }
+
+    /**
+     * Sets the file limit
+     * @param limit the limit for a file.
+     */
+    set fileLimit(limit: number) {
+        this._fileLimit = limit;
+    }
+
+    /**
      * Get the configuration value for the given preference id.
      * @param id the unique identifier for the preference.
      * @returns the configuration value.
@@ -105,5 +126,14 @@ export class LocalHistoryPreferencesService {
     private getFileSizeLimit(): number {
         const value = this.getPreferenceValueById(FILE_SIZE_LIMIT.id);
         return typeof value === 'number' ? value : FILE_SIZE_LIMIT.default as number;
+    }
+
+    /**
+     * Get the configuration value for 'FILE_LIMIT'
+     * 
+     */
+    private getFileLimit(): number {
+        const value = this.getPreferenceValueById(FILE_LIMIT.id);
+        return typeof value === 'number' ? value : FILE_LIMIT.default as number;
     }
 }

--- a/src/local-history/local-history-preferences.ts
+++ b/src/local-history/local-history-preferences.ts
@@ -35,3 +35,11 @@ export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
     id: 'local-history.fileSizeLimit',
     default: 25
 };
+
+/**
+ * Limits the maximum number of revisions saved per file. 
+ */
+export const FILE_LIMIT: LocalHistoryPreference = {
+    id: 'local-history.fileLimit',
+    default: 30
+};


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/76

**What it Does**
This allows the user to set a limit for the number of revisions they
want for each file, it is helpful in files which are super large as it
will not flush extra storage.

It removes the oldest revision of that file and adds a new revision on
top.

**How to Test**

`Due to the bug caused by #40, if testing is done in windows, it would be better if the user creates multiple history revisions in one host, close it, and then using a fresh host try to do the remaining steps. `

1. Open workspace
2. Make revisions up to the limit
3. Add a new revision, check to see if the total number of revisions stored are within the limit
4. Check to see if the latest save is stored as a revision
5. Check to see if the oldest revision is deleted or not. 

#40, still exists on this pr.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>