### PR TITLE
preference: limit the max file size for a revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
                     "type": "number",
                     "default": 5000,
                     "description": "Controls the save delay in milliseconds."
+                },
+                "local-history.fileSizeLimit": {
+                    "type": "number",
+                    "default": 25,
+                    "description": "Controls the maximum acceptable file size for storing revisions in megabytes."
                 }
             }
         }

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -139,6 +139,10 @@ export class LocalHistoryManager {
      * Save the current context of the active editor.
      */
     public async saveEditorContext(document: vscode.TextDocument): Promise<void> {
+        if (!this.fileSizeLimit(document)) {
+            return;
+        }
+
         const timestamp = this.getCurrentTime();
         const timestampForFileName = timestamp.replace(/[-:. ]/g, '');
         const fileFullPath = path.parse(document.fileName);
@@ -372,5 +376,18 @@ export class LocalHistoryManager {
         catch (err) {
             console.log(err);
         }
+    }
+
+    /**
+     * Checks the size of file in active editor against the preference value 'fileSizeLimit'
+     * @param document Represent the active text document.
+     */
+    private fileSizeLimit(document: vscode.TextDocument): boolean {
+        const sizeInBytes = fs.statSync(document.uri.fsPath).size;
+        const sizeInMegaBytes = sizeInBytes / 1000000;
+        if (sizeInMegaBytes > this.localHistoryPreferencesService.fileSizeLimit) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -1,14 +1,16 @@
 import * as vscode from 'vscode';
-import { MAX_ENTRIES_PER_FILE, SAVE_DELAY } from './local-history-preferences';
+import { MAX_ENTRIES_PER_FILE, SAVE_DELAY, FILE_SIZE_LIMIT } from './local-history-preferences';
 
 export class LocalHistoryPreferencesService {
 
     private _maxEntriesPerFile: number = MAX_ENTRIES_PER_FILE.default;
     private _saveDelay: number = SAVE_DELAY.default;
+    private _fileSizeLimit: number = FILE_SIZE_LIMIT.default;
 
     constructor() {
         this.maxEntriesPerFile = this.getMaxEntriesPerFile();
         this.saveDelay = this.getSaveDelay();
+        this.fileSizeLimit = this.getFileSizeLimit();
 
         // Listen to changes to the preferences configuration and update accordingly.
         vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
@@ -17,6 +19,9 @@ export class LocalHistoryPreferencesService {
             }
             if (event.affectsConfiguration(SAVE_DELAY.id)) {
                 this.saveDelay = this.getSaveDelay();
+            }
+            if (event.affectsConfiguration(FILE_SIZE_LIMIT.id)) {
+                this.fileSizeLimit = this.getFileSizeLimit();
             }
         });
     }
@@ -54,6 +59,22 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
+     * Get the file size limit in megabytes.
+     * @returns the file size limit in megabytes.
+     */
+    get fileSizeLimit(): number {
+        return this._fileSizeLimit;
+    }
+
+    /**
+     * Set the file size limit.
+     * @param limit the file size limit in megabytes.
+     */
+    set fileSizeLimit(limit: number) {
+        this._fileSizeLimit = limit;
+    }
+
+    /**
      * Get the configuration value for the given preference id.
      * @param id the unique identifier for the preference.
      * @returns the configuration value.
@@ -76,5 +97,13 @@ export class LocalHistoryPreferencesService {
     private getSaveDelay(): number {
         const value = this.getPreferenceValueById(SAVE_DELAY.id);
         return typeof value === 'number' ? value : SAVE_DELAY.default as number;
+    }
+
+    /**
+     * Get the configuration value for 'FILE_SIZE_LIMIT'
+     */
+    private getFileSizeLimit(): number {
+        const value = this.getPreferenceValueById(FILE_SIZE_LIMIT.id);
+        return typeof value === 'number' ? value : FILE_SIZE_LIMIT.default as number;
     }
 }

--- a/src/local-history/local-history-preferences.ts
+++ b/src/local-history/local-history-preferences.ts
@@ -27,3 +27,11 @@ export const SAVE_DELAY: LocalHistoryPreference = {
     id: 'local-history.saveDelay',
     default: 5000
 };
+
+/**
+ * Controls the maximum acceptable file size for storing revisions.
+ */
+export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
+    id: 'local-history.fileSizeLimit',
+    default: 25
+};


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/77

**What it Does**
Adds a preference which caps the maximum file size in order to create a
local history file, in the file-size od the active document is within
the boundary then it will perform a save, else it won't.

**How to Test**
1. Open the workspace with a file size greater than the limit
2. Try to make changes and perform save
3. Check to see if the file is saved or not.

For testing, a dummy file can be used. 
[testing.txt](https://github.com/vince-fugnitto/local-history-ext/files/4626282/testing.txt)

In order to test the functionality with this test file, you can set the preference value to a lesser value than the file size, for eg `0.13` will work with this file.