### PR TITLE
Save current state of file as a revision before revert

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,12 +108,12 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "local-history.undoRevert",
+                    "command": "local-history.removeRevision",
                     "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
                     "group": "navigation@2"
                 },
                 {
-                    "command": "local-history.removeRevision",
+                    "command": "local-history.undoRevert",
                     "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
                     "group": "navigation@3"
                 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
                 "command": "local-history.refreshEntry",
                 "title": "Local History: Refresh",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "local-history.undoRevert",
+                "title": "Local History: Undo Revert",
+                "icon": "$(discard)"
             }
         ],
         "menus": {
@@ -90,6 +95,10 @@
                 {
                     "command": "local-history.clearHistory",
                     "when": "editorIsOpen && resourceScheme == file"
+                },
+                {
+                    "command": "local-history.undoRevert",
+                    "when": "false"
                 }
             ],
             "editor/title": [
@@ -99,9 +108,14 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "local-history.removeRevision",
+                    "command": "local-history.undoRevert",
                     "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
                     "group": "navigation@2"
+                },
+                {
+                    "command": "local-history.removeRevision",
+                    "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
+                    "group": "navigation@3"
                 }
             ],
             "editor/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,16 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Command which undoes a revert.
+    disposable.push(
+        vscode.commands.registerTextEditorCommand('local-history.undoRevert', () => {
+            const editors = vscode.window.visibleTextEditors;
+            if (editors && editors.length === 2) {
+                manager.undoRevert(editors[1]);
+            }
+        })
+    );
+
     context.subscriptions.push(...disposable);
 
     // Tree View


### PR DESCRIPTION
**Description**
- Create a revision before reverting
- Allow users to undo a revert
- Prevent user from reverting to the same revisions more than once
- Add revision context metadata (revert change, manual change) to filenames for revisions

**How to test**
1. Open a file which does not contain any local-history (clear history if required - ex: rm -rf ~/.local-history)
2. Save the file and view local history for that file (should see a revision with a filename containing `_m`)
3. Create 2 more revisions
4. View the first revision in diff and click the `revert` icon
5. After reverting, confirm that a new revision is created (the filename should contain `_r`)
6. Click the `revert` icon again (**nothing should happen**)
7. Now, click the `undo revert` icon
8. After undoing the revert, click the `undo revert` icon again (**nothing should happen**)


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>