### PR TITLE
Track deleted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,12 @@
     "contributes": {
         "viewsWelcome": [
             {
-                "view": "localHistoryTree",
+                "view": "localHistoryRevisionTree",
                 "contents": "No local history found."
+            },
+            {
+                "view": "localHistoryDeletionTree",
+                "contents": "No deleted files found."
             }
         ],
         "viewsContainers": {
@@ -38,8 +42,12 @@
         "views": {
             "localHistory": [
                 {
-                    "id": "localHistoryTree",
+                    "id": "localHistoryRevisionTree",
                     "name": "Active Editor Revisions"
+                },
+                {
+                    "id": "localHistoryDeletionTree",
+                    "name": "Workspace deleted files"
                 }
             ]
         },
@@ -68,8 +76,13 @@
                 "title": "Local History: Clear Old History"
             },
             {
-                "command": "local-history.refreshEntry",
-                "title": "Local History: Refresh",
+                "command": "local-history.refreshRevisionEntry",
+                "title": "Local History: Refresh Active Editor Revision",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "local-history.refreshDeletionEntry",
+                "title": "Local History: Refresh Workspace Deleted Files",
                 "icon": "$(refresh)"
             }
         ],
@@ -119,26 +132,31 @@
             "explorer/context": [
                 {
                     "command": "local-history.viewHistory",
-                    "when": "!explorerResourceIsFolder",
+                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot",
                     "group": "LocalHistory@1"
                 },
                 {
                     "command": "local-history.clearHistory",
-                    "when": "!explorerResourceIsFolder",
+                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot",
                     "group": "LocalHistory@2"
                 }
             ],
             "view/title": [
                 {
-                    "command": "local-history.refreshEntry",
-                    "when": "view == localHistoryTree",
+                    "command": "local-history.refreshRevisionEntry",
+                    "when": "view == localHistoryRevisionTree",
+                    "group": "navigation"
+                },
+                {
+                    "command": "local-history.refreshDeletionEntry",
+                    "when": "view == localHistoryDeletionTree",
                     "group": "navigation"
                 }
             ],
             "view/item/context": [
                 {
                     "command": "local-history.removeRevision",
-                    "when": "view == localHistoryTree",
+                    "when": "view == localHistoryRevisionTree",
                     "group": "inline"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { LocalHistoryManager } from './local-history/local-history-manager';
-import { LocalHistoryTreeProvider } from './local-history/local-history-tree-provider';
+import { LocalHistoryRevisionTreeProvider } from './local-history/local-history-revision-tree-provider';
 import { Commands } from './local-history/local-history-types';
+import { LocalHistoryDeletionTreeProvider } from './local-history/local-history-deletion-tree-provider';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -89,11 +90,18 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(...disposable);
 
     // Tree View
-    const treeProvider = new LocalHistoryTreeProvider(manager);
-    vscode.window.registerTreeDataProvider('localHistoryTree', treeProvider);
-    vscode.commands.registerCommand(Commands.TREE_REFRESH, () => treeProvider.refresh());
+    const revisionTreeProvider = new LocalHistoryRevisionTreeProvider(manager);
+    const deletionTreeProvider = new LocalHistoryDeletionTreeProvider(manager);
+    vscode.window.registerTreeDataProvider('localHistoryRevisionTree', revisionTreeProvider);
+    vscode.window.registerTreeDataProvider('localHistoryDeletionTree', deletionTreeProvider);
+    vscode.commands.registerCommand(Commands.TREE_REVISION_REFRESH, () => revisionTreeProvider.refresh());
     vscode.commands.registerCommand(Commands.TREE_DIFF, uri =>
         manager.displayDiff(vscode.Uri.file(uri), vscode.window.activeTextEditor!.document.uri));
+
+    vscode.commands.registerCommand(Commands.TREE_DELETED_FILE, (selectionUri) =>
+        vscode.workspace.openTextDocument(selectionUri).then(doc => vscode.window.showTextDocument(doc)));
+    vscode.commands.registerCommand(Commands.TREE_DELETION_REFRESH, () => deletionTreeProvider.refresh());
+
 }
 
 export function deactivate() { }

--- a/src/local-history/local-history-deletion-tree-provider.ts
+++ b/src/local-history/local-history-deletion-tree-provider.ts
@@ -1,0 +1,106 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as moment from 'moment';
+import { LocalHistoryManager } from './local-history-manager';
+import { HistoryFileProperties, LOCAL_HISTORY_DIRNAME, LOCAL_HISTORY_DELETION_DIRNAME } from './local-history-types';
+
+export class DeletedFile extends vscode.TreeItem {
+    uri: string;
+    timestamp: string;
+
+    constructor(label: string, uri: string, timestamp: string, command: vscode.Command) {
+        super(label);
+        this.label = label;
+        this.uri = uri;
+        this.timestamp = timestamp;
+        this.command = command;
+    }
+
+    get tooltip(): string {
+        return `Open '${path.basename(this.uri)}'`;
+    }
+
+    get description(): string {
+        return `Deleted ${moment(this.timestamp).fromNow()}`;
+    }
+}
+
+export class LocalHistoryDeletionTreeProvider implements vscode.TreeDataProvider<DeletedFile> {
+    private _onDidChangeTreeData: vscode.EventEmitter<DeletedFile | undefined> = new vscode.EventEmitter<DeletedFile | undefined>();
+    readonly onDidChangeTreeData: vscode.Event<DeletedFile | undefined> = this._onDidChangeTreeData.event;
+    readonly manager: LocalHistoryManager;
+
+    constructor(manager: LocalHistoryManager) {
+        this.manager = manager;
+
+        vscode.workspace.onDidDeleteFiles(() => {
+            this.refresh();
+        });
+    }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: DeletedFile): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): Thenable<DeletedFile[]> {
+        if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 0) {
+            return Promise.resolve([]);
+        } else {
+            return Promise.resolve(this.getWorkspaceDeletedFiles(vscode.workspace.workspaceFolders[0].uri.fsPath));
+        }
+    }
+
+    /**
+     * Get all deleted files for the workspace
+     */
+    private async getWorkspaceDeletedFiles(workspacePath: string): Promise<DeletedFile[]> {
+        const deletions: DeletedFile[] = [];
+        const hashedWorkspacePath = vscode.Uri.file(path.normalize(path.join(os.homedir(), LOCAL_HISTORY_DIRNAME, LOCAL_HISTORY_DELETION_DIRNAME, this.manager.checksum(workspacePath))));
+
+        if (!fs.existsSync(hashedWorkspacePath.fsPath)) {
+            return deletions;
+        } else {
+            await this.readDirRec(hashedWorkspacePath);
+            const deletedFiles = this.manager.workspaceDeletedFiles;
+
+            deletedFiles.forEach(item => {
+                deletions.push(new DeletedFile(item.fileName, item.uri, item.timestamp, {
+                    command: 'extension.openDeletedFile',
+                    title: '',
+                    arguments: [item.uri]
+                }));
+            });
+
+            return deletions;
+        }
+
+    }
+
+    /**
+     * Read a directory recursively.
+     */
+    private async readDirRec(folderUri: vscode.Uri): Promise<void> {
+        for (const [fileName, type] of await vscode.workspace.fs.readDirectory(folderUri)) {
+            if (type === vscode.FileType.File) {
+                const data: HistoryFileProperties = {
+                    fileName: fileName,
+                    timestamp: `${moment(fs.statSync(path.join(folderUri.fsPath, fileName)).birthtimeMs).format()}`,
+                    uri: path.join(folderUri.fsPath, fileName),
+                };
+                if (!this.manager.workspaceDeletedFiles.find(prop => prop.uri === data.uri)) {
+                    this.manager.workspaceDeletedFiles.unshift(data);
+                }
+            }
+            else if (type === vscode.FileType.Directory) {
+                const childFolderUri = folderUri.with({ path: path.join(folderUri.fsPath, fileName) });
+                this.readDirRec(childFolderUri);
+            }
+        }
+    }
+}

--- a/src/local-history/local-history-revision-tree-provider.ts
+++ b/src/local-history/local-history-revision-tree-provider.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as moment from 'moment';
-// eslint-disable-next-line no-unused-vars
 import { LocalHistoryManager } from './local-history-manager';
 
 export class Revision extends vscode.TreeItem {
@@ -23,7 +22,7 @@ export class Revision extends vscode.TreeItem {
     }
 }
 
-export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revision> {
+export class LocalHistoryRevisionTreeProvider implements vscode.TreeDataProvider<Revision> {
     private _onDidChangeTreeData: vscode.EventEmitter<Revision | undefined> = new vscode.EventEmitter<Revision | undefined>();
     readonly onDidChangeTreeData: vscode.Event<Revision | undefined> = this._onDidChangeTreeData.event;
     readonly manager: LocalHistoryManager;
@@ -55,9 +54,9 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
     /**
      * Get all revisions for active editor
      */
-    private async getRevisionsActiveEditor(editor: string): Promise<Revision[]> {
+    private async getRevisionsActiveEditor(editorPath: string): Promise<Revision[]> {
         const revisions: Revision[] = [];
-        const hashedFolderPath = this.manager.getHashedRevisionFolderPath(editor);
+        const hashedFolderPath = this.manager.getHashedRevisionFolderPath(editorPath);
         await this.manager.loadHistory(hashedFolderPath);
         const history = this.manager.historyFilesForActiveEditor;
         history.forEach(item => {
@@ -69,4 +68,5 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
         });
         return revisions;
     }
+
 }

--- a/src/local-history/local-history-tree-provider.ts
+++ b/src/local-history/local-history-tree-provider.ts
@@ -57,7 +57,7 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
      */
     private async getRevisionsActiveEditor(editor: string): Promise<Revision[]> {
         const revisions: Revision[] = [];
-        const hashedFolderPath = this.manager.getHashedFolderPath(editor);
+        const hashedFolderPath = this.manager.getHashedRevisionFolderPath(editor);
         await this.manager.loadHistory(hashedFolderPath);
         const history = this.manager.historyFilesForActiveEditor;
         history.forEach(item => {

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -6,6 +6,14 @@ export const DAY_TO_MILLISECONDS = 86400000;
  * The local history directory name.
  */
 export const LOCAL_HISTORY_DIRNAME = '.local-history';
+/**
+ * The revisions directory name.
+ */
+export const LOCAL_HISTORY_REVISIONS_DIRNAME = 'revisions';
+/**
+ * The deleted files directory name.
+ */
+export const LOCAL_HISTORY_DELETION_DIRNAME = 'deletedFiles';
 
 /**
  * Describes a local-history preference.

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -93,7 +93,9 @@ export namespace Commands {
     export const CLEAR_OLD_HISTORY = 'local-history.clearOldHistory';
     export const REMOVE_REVISION = 'local-history.removeRevision';
     export const REVERT_TO_PREVIOUS_REVISION = 'local-history.revertToPrevRevision';
+    export const TREE_DELETED_FILE = 'extension.openDeletedFile';
     export const TREE_DIFF = 'extension.openRevisionInDiff';
-    export const TREE_REFRESH = 'local-history.refreshEntry';
+    export const TREE_DELETION_REFRESH = 'local-history.refreshDeletionEntry';
+    export const TREE_REVISION_REFRESH = 'local-history.refreshRevisionEntry';
     export const VIEW_HISTORY = 'local-history.viewHistory';
 }


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/80

**What it Does**
- Tracks deleted files in the current workspace, so it can be restored at any point in the future.
- Save all deleted files under **workspacePath hash** in `.local-history`
- List all deleted files for a workspace in a new tree-view
- Click on a deleted file in tree-view to open it
- Refresh entries in the new tree-view by either clicking the `Refresh` button, deleting a file or changing workspace

**How to Test**
1. When no workspace folder is found, you should see a mesage in tree-view: `No deleted files found`
2. Open a folder in workspace and **make sure it does not contain any local-history** (clear history if required - ex: rm -rf ~/.local-history)
3. Delete a file in the workspace
4. Go to Local History tree-view and refresh if you do not see a node for the deleted file
5. Hover over a tree node to see tooltip text `Open 123.ts'
6. Click on a node in tree-view to open it
7. Check to see if file exists in  `.local-history/deletedFiles/(your hash)/file.`

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>
Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>