### PR TITLE
preference: support filesExclude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,14 +266,12 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -409,8 +407,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -1230,7 +1227,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}

--- a/package.json
+++ b/package.json
@@ -166,6 +166,14 @@
                     "default": 30,
                     "minimum": 1,
                     "description": "Controls the maximum number of saved revisions allowed for a given file"
+                },
+                "local-history.excludeFiles": {
+                    "type": "object",
+                    "markdownDescription": "Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `Files: Exclude setting`. The glob includes `**./local-history/**` as default. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+                    "default": {
+                        "**/.local-history/**": true
+                    },
+                    "scope": "resource"
                 }
             }
         }
@@ -195,6 +203,7 @@
         "vscode-test": "^1.2.2"
     },
     "dependencies": {
+        "minimatch": "^3.0.4",
         "moment": "2.24.0"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,6 +86,21 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    //Triggers autocomplete for '**/.local-history' in json files
+    disposable.push(vscode.languages.registerCompletionItemProvider({ language: 'json', scheme: '*' }, {
+
+        provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
+
+            // A completion item which inserts `**/.local-history`
+            const localHistorySettingCompletion = new vscode.CompletionItem('"**/.local-history/**"');
+
+            // Return all completion items as array
+            return [
+                localHistorySettingCompletion
+            ];
+        }
+    }));
+
     context.subscriptions.push(...disposable);
 
     // Tree View

--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -3,12 +3,14 @@ import { Preferences } from './local-history-types';
 
 export class LocalHistoryPreferencesService {
 
+    private _excludedFiles: object = Preferences.EXCLUDE_FILES.default;
     private _fileLimit: number = Preferences.FILE_LIMIT.default;
     private _fileSizeLimit: number = Preferences.FILE_SIZE_LIMIT.default;
     private _maxEntriesPerFile: number = Preferences.MAX_ENTRIES_PER_FILE.default;
     private _saveDelay: number = Preferences.SAVE_DELAY.default;
 
     constructor() {
+        this.excludedFiles = this.getExcludedFiles();
         this.fileLimit = this.getFileLimit();
         this.fileSizeLimit = this.getFileSizeLimit();
         this.maxEntriesPerFile = this.getMaxEntriesPerFile();
@@ -16,19 +18,70 @@ export class LocalHistoryPreferencesService {
 
         // Listen to changes to the preferences configuration and update accordingly.
         vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+            if (event.affectsConfiguration(Preferences.EXCLUDE_FILES.id || 'files.exclude')) {
+                this.excludedFiles = this.getExcludedFiles();
+            }
+            if (event.affectsConfiguration(Preferences.FILE_LIMIT.id)) {
+                this.fileLimit = this.getFileLimit();
+            }
+            if (event.affectsConfiguration(Preferences.FILE_SIZE_LIMIT.id)) {
+                this.fileSizeLimit = this.getFileSizeLimit();
+            }
             if (event.affectsConfiguration(Preferences.MAX_ENTRIES_PER_FILE.id)) {
                 this.maxEntriesPerFile = this.getMaxEntriesPerFile();
             }
             if (event.affectsConfiguration(Preferences.SAVE_DELAY.id)) {
                 this.saveDelay = this.getSaveDelay();
             }
-            if (event.affectsConfiguration(Preferences.FILE_SIZE_LIMIT.id)) {
-                this.fileSizeLimit = this.getFileSizeLimit();
-            }
-            if (event.affectsConfiguration(Preferences.FILE_LIMIT.id)) {
-                this.fileLimit = this.getFileLimit();
-            }
         });
+    }
+
+    /**
+     * Get the excluded files.
+     * @returns the excluded files.
+     */
+    get excludedFiles(): object {
+        return this._excludedFiles;
+    }
+
+    /**
+     * Set the excluded file
+     * @param files the excluded files.
+     */
+    set excludedFiles(files: object) {
+        this._excludedFiles = files;
+    }
+
+    /**
+     * Get the revision limit for a file.
+     * @returns the file limit.
+     */
+    get fileLimit(): number {
+        return this._fileLimit;
+    }
+
+    /**
+     * Sets the file limit
+     * @param limit the limit for a file.
+     */
+    set fileLimit(limit: number) {
+        this._fileLimit = limit;
+    }
+
+    /**
+     * Get the file size limit in megabytes.
+     * @returns the file size limit in megabytes.
+     */
+    get fileSizeLimit(): number {
+        return this._fileSizeLimit;
+    }
+
+    /**
+     * Set the file size limit.
+     * @param limit the file size limit in megabytes.
+     */
+    set fileSizeLimit(limit: number) {
+        this._fileSizeLimit = limit;
     }
 
     /**
@@ -64,44 +117,38 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
-     * Get the file size limit in megabytes.
-     * @returns the file size limit in megabytes.
-     */
-    get fileSizeLimit(): number {
-        return this._fileSizeLimit;
-    }
-
-    /**
-     * Set the file size limit.
-     * @param limit the file size limit in megabytes.
-     */
-    set fileSizeLimit(limit: number) {
-        this._fileSizeLimit = limit;
-    }
-
-    /**
-     * Get the revision limit for a file.
-     * @returns the file limit.
-     */
-    get fileLimit(): number {
-        return this._fileLimit;
-    }
-
-    /**
-     * Sets the file limit
-     * @param limit the limit for a file.
-     */
-    set fileLimit(limit: number) {
-        this._fileLimit = limit;
-    }
-
-    /**
      * Get the configuration value for the given preference id.
      * @param id the unique identifier for the preference.
      * @returns the configuration value.
      */
     private getPreferenceValueById(id: string): any {
         return vscode.workspace.getConfiguration().get(id);
+    }
+
+    /**
+     * Get the configuration value for 'EXCLUDE_FILES'
+     */
+    private getExcludedFiles(): object {
+        const value = this.getPreferenceValueById(Preferences.EXCLUDE_FILES.id);
+        const filesExcludeValue = this.getPreferenceValueById('files.exclude');
+        return typeof value === 'object' && typeof filesExcludeValue === 'object' ? { ...value, ...filesExcludeValue } : Preferences.EXCLUDE_FILES.default as object;
+    }
+
+    /**
+     * Get the configuration value for 'FILE_LIMIT'
+     *
+     */
+    private getFileLimit(): number {
+        const value = this.getPreferenceValueById(Preferences.FILE_LIMIT.id);
+        return typeof value === 'number' ? value : Preferences.FILE_LIMIT.default as number;
+    }
+
+    /**
+     * Get the configuration value for 'FILE_SIZE_LIMIT'
+     */
+    private getFileSizeLimit(): number {
+        const value = this.getPreferenceValueById(Preferences.FILE_SIZE_LIMIT.id);
+        return typeof value === 'number' ? value : Preferences.FILE_SIZE_LIMIT.default as number;
     }
 
     /**
@@ -118,22 +165,5 @@ export class LocalHistoryPreferencesService {
     private getSaveDelay(): number {
         const value = this.getPreferenceValueById(Preferences.SAVE_DELAY.id);
         return typeof value === 'number' ? value : Preferences.SAVE_DELAY.default as number;
-    }
-
-    /**
-     * Get the configuration value for 'FILE_SIZE_LIMIT'
-     */
-    private getFileSizeLimit(): number {
-        const value = this.getPreferenceValueById(Preferences.FILE_SIZE_LIMIT.id);
-        return typeof value === 'number' ? value : Preferences.FILE_SIZE_LIMIT.default as number;
-    }
-
-    /**
-     * Get the configuration value for 'FILE_LIMIT'
-     *
-     */
-    private getFileLimit(): number {
-        const value = this.getPreferenceValueById(Preferences.FILE_LIMIT.id);
-        return typeof value === 'number' ? value : Preferences.FILE_LIMIT.default as number;
     }
 }

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -45,6 +45,16 @@ export interface HistoryFileProperties {
 export namespace Preferences {
 
     /**
+     * Exclude the local history for the files.
+     */
+    export const EXCLUDE_FILES: LocalHistoryPreference = {
+        id: 'local-history.excludeFiles',
+        default: {
+            '**/.local-history/**': true,
+        }
+    };
+
+    /**
      * Limits the maximum number of revisions saved per file.
      */
     export const FILE_LIMIT: LocalHistoryPreference = {
@@ -75,6 +85,7 @@ export namespace Preferences {
         id: 'local-history.saveDelay',
         default: 5000
     };
+
 }
 
 /**

--- a/src/test/suite/local-history-preference-service.test.ts
+++ b/src/test/suite/local-history-preference-service.test.ts
@@ -62,6 +62,27 @@ mocha.suite('LocalHistoryPreferencesService', () => {
         });
     });
 
+    mocha.describe(`Preference: '${Preferences.EXCLUDE_FILES.id}'`, () => {
+        mocha.it('should return the correct default value', () => {
+            const mergedDefault: Object = {
+                '**/.DS_Store': true,
+                '**/.git': true,
+                '**/.hg': true,
+                '**/.local-history/**': true,
+                '**/.svn': true,
+                '**/CVS': true
+            };
+            const glob: Object = { '**/.local-history/**': true };
+            assert.deepEqual(glob, Preferences.EXCLUDE_FILES.default);
+            assert.deepEqual(service.excludedFiles, mergedDefault);
+        });
+        mocha.it('should properly update the value', () => {
+            const updatedValue: object = { '**/*.txt': true };
+            service.excludedFiles = updatedValue;
+            assert.equal(service.excludedFiles, updatedValue);
+        });
+    });
+
     mocha.describe('Method: getPreferenceValueById', () => {
         mocha.it(`should properly return the '${Preferences.FILE_LIMIT.id}' preference`, () => {
             assert.equal(service['getPreferenceValueById'](Preferences.FILE_LIMIT.id), Preferences.FILE_LIMIT.default);
@@ -74,6 +95,9 @@ mocha.suite('LocalHistoryPreferencesService', () => {
         });
         mocha.it(`should properly return the '${Preferences.SAVE_DELAY.id}' preference`, () => {
             assert.equal(service['getPreferenceValueById'](Preferences.SAVE_DELAY.id), Preferences.SAVE_DELAY.default);
+        });
+        mocha.it(`should properly return the '${Preferences.EXCLUDE_FILES.id}' preference`, () => {
+            assert.deepEqual(service['getPreferenceValueById'](Preferences.EXCLUDE_FILES.id), Preferences.EXCLUDE_FILES.default);
         });
     });
 


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/89

This allows the user to exclude the files for which they dont want local
history of.

**How to Test**
1. Open a workspace
2. In the Preference>Local History> Excluded Files
3. Edit json file to update the files.
4. Add `"**/*.txt" : true`. 
4. Save and create a new `.txt` file
5. Make changes and save. 
6. Press `f1` and `Local History: Active Editor`
4. Check to see if the history for that source file is created

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>