### PR TITLE
Remove empty folders

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -395,6 +395,7 @@ export class LocalHistoryManager {
                         for (const file of fileUris) {
                             fs.unlinkSync(file);
                         }
+                        this.removeEmptyFolders();
                         vscode.window.showInformationMessage(`Successfully deleted ${fileUris.length} local-history file(s)`);
                         vscode.commands.executeCommand('local-history.refreshEntry');
                     }
@@ -449,6 +450,9 @@ export class LocalHistoryManager {
             if (oldestRevision) {
                 fs.unlinkSync(oldestRevision);
             }
+            if (!fs.readdirSync(hashedPath).length) {
+                fs.rmdirSync(hashedPath);
+            }
         }
     }
 
@@ -473,6 +477,20 @@ export class LocalHistoryManager {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes empty folders.
+     */
+    private removeEmptyFolders() {
+        const localHistoryDir = path.normalize(path.join(os.homedir(), LOCAL_HISTORY_DIRNAME));
+        const folders = fs.readdirSync(localHistoryDir);
+        for (const folder of folders) {
+            const folderPath = path.normalize(path.join(localHistoryDir, folder));
+            if (!fs.readdirSync(folderPath).length) {
+                fs.rmdirSync(folderPath);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/87

Upon clearing the history files, if the folder is empty, it will also
remove that specific folder.

**How to Test**
1.Open a folder in workspace
2. Create multiple revisions. 
3. (For testing purposes change the variable `DAY_TO_MILLISECONDS` inside  `local-history-types.ts` to around `5`
4. Restart the host, perform `f1` `Local History: Clear Old History`. Enter `1` day. 
5. Check to see inside `home/.local-history` if the folder exists or not. 

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>