### PR TITLE
test: add tests for 'isFileExcluded`

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -130,7 +130,7 @@ export class LocalHistoryManager {
      * Save the current context of the active editor.
      */
     public async saveEditorContext(document: vscode.TextDocument): Promise<void> {
-        if (!this.fileSizeLimit(document) || this.excludeFiles(document)) {
+        if (!this.fileSizeLimit(document) || this.isFileExcluded(document)) {
             return;
         }
 
@@ -460,10 +460,10 @@ export class LocalHistoryManager {
     }
 
     /**
-     * Exclude the revisions of sources which follows the glob pattern. 
+     * Exclude the revisions of sources which follows the glob pattern.
      * @param document Represent the active text document.
      */
-    private excludeFiles(document: vscode.TextDocument): boolean {
+    private isFileExcluded(document: vscode.TextDocument): boolean {
         const glob = Object.keys(this.localHistoryPreferencesService.excludedFiles);
         const documentUri = path.normalize(document.uri.fsPath);
         for (const pattern of glob) {

--- a/src/test/suite/local-history-manager.test.ts
+++ b/src/test/suite/local-history-manager.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as mocha from 'mocha';
 import * as vscode from 'vscode';
 import { LocalHistoryManager } from '../../local-history/local-history-manager';
+import { MockTextDocument } from './mock-text-document';
 
 mocha.suite('LocalHistoryManager', () => {
 
@@ -18,6 +19,33 @@ mocha.suite('LocalHistoryManager', () => {
             const b: string = 'foobar_19940311081234_100.ts';
             assert.equal(manager['parseTimestamp'](a), '2020-05-08 15:39:53');
             assert.equal(manager['parseTimestamp'](b), '1994-03-11 08:12:34');
+        });
+    });
+
+    mocha.describe('Method: isFileExcluded', () => {
+        mocha.it('it should properly exclude `.local-history` files', async () => {
+            const uri = vscode.Uri.parse('.local-history/a/a.ts');
+            const document: MockTextDocument = new MockTextDocument(uri, '');
+            const match = manager['isFileExcluded'](document);
+            assert.equal(match, true);
+        });
+        mocha.it('it should properly exclude nested `.local-history` files', async () => {
+            const uri = vscode.Uri.parse('.local-history/a/b/c/a.ts');
+            const document: MockTextDocument = new MockTextDocument(uri, '');
+            const match = manager['isFileExcluded'](document);
+            assert.equal(match, true);
+        });
+        mocha.it('it should properly exclude `.local-history` files as a subdirectory', async () => {
+            const uri = vscode.Uri.parse('foo/bar/.local-history/a.ts');
+            const document: MockTextDocument = new MockTextDocument(uri, '');
+            const match = manager['isFileExcluded'](document);
+            assert.equal(match, true);
+        });
+        mocha.it('it should return `false` for files which are not excluded', async () => {
+            const uri = vscode.Uri.parse('foo/bar/a.ts');
+            const document: MockTextDocument = new MockTextDocument(uri, '');
+            const match = manager['isFileExcluded'](document);
+            assert.equal(match, false);
         });
     });
 

--- a/src/test/suite/mock-text-document.ts
+++ b/src/test/suite/mock-text-document.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+
+export class MockTextDocument implements vscode.TextDocument {
+
+    languageId: string = '';
+
+    isUntitled: boolean = false;
+    isDirty: boolean = false;
+    isClosed: boolean = false;
+
+    eol: vscode.EndOfLine = vscode.EndOfLine.LF;
+
+    private readonly _lines: string[];
+
+    constructor(
+        public readonly uri: vscode.Uri,
+        private readonly _contents: string,
+        public readonly version = 1,
+    ) {
+        this._lines = this._contents.split(/\n/g);
+    }
+
+    get fileName(): string {
+        return this.uri.fsPath;
+    }
+    get lineCount(): number {
+        return this._lines.length;
+    }
+    getText(_?: vscode.Range | undefined): never {
+        throw new Error('');
+    }
+    getWordRangeAtPosition(_a: vscode.Position, _b?: RegExp): never {
+        throw new Error('');
+    }
+    lineAt(_: any): never {
+        throw new Error('');
+    }
+    offsetAt(_: vscode.Position): never {
+        throw new Error('');
+    }
+    positionAt(_: number): never {
+        throw new Error('');
+    }
+    save(): never {
+        throw new Error('');
+    }
+    validatePosition(_: vscode.Position): never {
+        throw new Error('');
+    }
+    validateRange(_: vscode.Range): never {
+        throw new Error('');
+    }
+}


### PR DESCRIPTION
**Description**

The following pull-request:
1. refactors the method name from `excludeFiles` to `isFileExcluded`
2. adds tests for `isFileExcluded` which is ultimately used to determine if the given document should have it's local-history saved, or if it is exempted due to exclude globs.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>