### PR TITLE
command: add 'view documentation' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 The **Local History** extension manages local revisions of a file independently of source control providers, and allows users to easily view, track, and restore files based on previous checkpoints. The extension is particularly useful for disaster recovery.
 
+### Documentation
+
+- #### Commands
+
+- #### Preferences
+
 ### Development
 
 - [QuickStart](./vsc-extension-quickstart.md)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
                 "command": "local-history.refreshEntry",
                 "title": "Local History: Refresh",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "local-history:viewDocumentation",
+                "title": "Local History: View Documentation"
             }
         ],
         "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,6 @@ export function activate(context: vscode.ExtensionContext) {
                 uri = vscode.window.activeTextEditor!.document.uri;
             }
             manager.viewHistory(uri);
-
         })
     );
 
@@ -86,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    //Triggers autocomplete for '**/.local-history' in json files
+    // Triggers autocomplete for '**/.local-history' in json files
     disposable.push(vscode.languages.registerCompletionItemProvider({ language: 'json', scheme: '*' }, {
 
         provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
@@ -99,6 +98,11 @@ export function activate(context: vscode.ExtensionContext) {
                 localHistorySettingCompletion
             ];
         }
+    }));
+
+    // Triggers opening the external documentation link.
+    disposable.push(vscode.commands.registerCommand(Commands.VIEW_DOCUMENTATION, () => {
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://github.com/vince-fugnitto/local-history-ext#documentation'));
     }));
 
     context.subscriptions.push(...disposable);

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -98,5 +98,6 @@ export namespace Commands {
     export const REVERT_TO_PREVIOUS_REVISION = 'local-history.revertToPrevRevision';
     export const TREE_DIFF = 'extension.openRevisionInDiff';
     export const TREE_REFRESH = 'local-history.refreshEntry';
+    export const VIEW_DOCUMENTATION = 'local-history:viewDocumentation';
     export const VIEW_HISTORY = 'local-history.viewHistory';
 }


### PR DESCRIPTION
**Description**

The following pull-request adds the new command `Local History: View Command`.
Triggering the command will open the external documentation link (repository readme section).

The documentation will be updated as part of #84 

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>