### PR TITLE
Save before revert

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showWarningMessage(`Are you sure you want to revert '${path.basename(editors[1].document.fileName)}' to its previous state?`, { modal: true }, 'Revert').then((selection) => {
                     if (selection === 'Revert') {
                         manager.revertToPrevRevision(editors[0], editors[1]);
+                        vscode.commands.executeCommand(Commands.TREE_REFRESH);
                     }
                 });
             }


### PR DESCRIPTION
**Description**
- Create a revision before reverting
- Prevent user from reverting to the same revisions more than once
- Add revision context metadata (revert change, manual change) to filenames for revisions

**How to test**

1. Open a file which does not contain any local-history
2. Save the file and view local history for that file (should see a revision with a filename containing _m)
3. Create 2 more revisions
4. View the first revision in diff and click the revert icon
5. After reverting, confirm that a new revision is created (the filename should contain _r)
6. Click the revert icon again (nothing should happen)