### PR TITLE
uses output channel to display warning/errors

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -8,6 +8,7 @@ import * as moment from 'moment';
 import * as minimatch from 'minimatch';
 
 import { HistoryFileProperties, LOCAL_HISTORY_DIRNAME, DAY_TO_MILLISECONDS, Commands } from './local-history-types';
+import { OutputManager } from './local-history-output-manager';
 
 export class LocalHistoryManager {
 
@@ -56,7 +57,7 @@ export class LocalHistoryManager {
                 }
             }
         } catch (err) {
-            console.warn(`An error has occurred when reading the ${LOCAL_HISTORY_DIRNAME} directory`, err);
+            OutputManager.appendWarningMessage([`An error has occurred when reading the ${LOCAL_HISTORY_DIRNAME} directory`, err]);
         }
     }
 
@@ -170,7 +171,7 @@ export class LocalHistoryManager {
             await this.writeFile(historyFilePath, activeDocumentContent, true);
         }
         catch (err) {
-            console.warn('An error has occurred when saving the active editor content', err);
+            OutputManager.appendWarningMessage(['An error has occurred when saving the active editor content', err]);
         }
     }
 
@@ -193,7 +194,7 @@ export class LocalHistoryManager {
                 const fileContent = await this.readFile(previous.document.fileName);
                 await this.writeFile(current.document.fileName, fileContent, false);
             } catch (err) {
-                console.warn('An error has occurred when reverting to previous revision', err);
+                OutputManager.appendWarningMessage(['An error has occurred when reverting to previous revision', err]);
             }
         }
     }
@@ -227,7 +228,7 @@ export class LocalHistoryManager {
                 // Change file permission to read-only.
                 fs.chmod(uri, 0o400, (err) => {
                     if (err) {
-                        console.warn(err);
+                        OutputManager.appendWarningMessage(err.message);
                     }
                 });
             }
@@ -242,7 +243,7 @@ export class LocalHistoryManager {
             // Remove the revision.
             fs.unlink(revision.fsPath, (err) => {
                 if (err) {
-                    console.warn('An error has occurred when removing the revision', err.message);
+                    OutputManager.appendWarningMessage('An error has occurred when removing the revision');
                     return;
                 }
 
@@ -289,7 +290,7 @@ export class LocalHistoryManager {
                     }
                 });
             } catch (err) {
-                console.warn(`An error has occurred when removing all the revision for ${path.basename(uri.fsPath)}`, err.message);
+                OutputManager.appendWarningMessage([`An error has occurred when removing all the revision for ${path.basename(uri.fsPath)}`, err.message]);
             }
         }
     }
@@ -405,7 +406,7 @@ export class LocalHistoryManager {
             }
         }
         catch (err) {
-            console.log(err);
+            OutputManager.appendErrorMessage(err.toString());
         }
     }
 
@@ -434,7 +435,7 @@ export class LocalHistoryManager {
                 return true;
             }
         } catch (err) {
-            console.log(err);
+            OutputManager.appendErrorMessage(err.toString());
         }
         return false;
     }
@@ -493,4 +494,3 @@ export class LocalHistoryManager {
         }
     }
 }
-

--- a/src/local-history/local-history-output-manager.ts
+++ b/src/local-history/local-history-output-manager.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import * as moment from 'moment';
+
+/**
+ * Representation of different severity log levels.
+ */
+enum Severity {
+    INFO = 'Info',
+    WARNING = 'Warning',
+    ERROR = 'Error',
+}
+
+export class OutputManager {
+
+    /**
+     * Logs the message in the output channel, with 'INFO' severity.
+     * @param messages The logged messages.
+     */
+    static appendInfoMessage(messages: string | string[]) {
+        this.appendMessage(Severity.INFO, messages);
+    }
+
+    /**
+     * Logs the message in the output channel, with 'WARNING' severity.
+     * @param messages The logged messages.
+     */
+    static appendWarningMessage(messages: string | string[]) {
+        this.appendMessage(Severity.WARNING, messages);
+    }
+
+    /**
+     * Logs the message in the output channel, with 'ERROR' severity.
+     * @param messages The logged messages.
+     */
+    static appendErrorMessage(messages: string | string[]) {
+        this.appendMessage(Severity.ERROR, messages);
+    }
+
+    /**
+     * Logs the message in the output channel.
+     * @param severity The type of message.
+     * @param messages The logged messages.
+     */
+    private static appendMessage(severity: Severity, messages: string | string[]): void {
+        const outputChannel = this.setupChannel();
+        const timestamp = moment().format('hh:mm:ss:ms');
+        if (typeof messages === 'string') {
+            outputChannel.appendLine(this.toLog(severity, timestamp, messages));
+            return;
+        }
+        messages.forEach((message: string) => {
+            outputChannel.appendLine(this.toLog(severity, timestamp, message));
+        });
+    }
+
+    /**
+     * Prints message to output channel.
+     * @param severity Representation of log level.
+     * @param timestamp Log time.
+     * @param message The logged messages.
+     */
+    private static toLog(severity: Severity, timestamp: string, message: string): string {
+        return `[${severity} - ${timestamp}]: ${message}`;
+    }
+
+    /**
+     * Creates an output channel.
+     */
+    private static setupChannel(): vscode.OutputChannel {
+        return vscode.window.createOutputChannel('Local History');
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/90

All the error messages will be printed directly to a seperate output
channel of Local History, this is done to not pollute the default output
channel for the user.

How to Test:
1. Open a workspace
2. Create a new file.
3. Without saving press `f1` -> `Local History: View History`
4. In the integrated output channel, try selecting `Local History` and check to see if the message is logged there with the appropriate timestamp and severity.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>