### PR TITLE
Commands for end-users to locate their revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,14 @@
             {
                 "command": "local-history:viewDocumentation",
                 "title": "Local History: View Documentation"
+            },
+            {
+                "command": "local-history.copyRevisionPath",
+                "title": "Local History: Copy Revision Path"
+            },
+            {
+                "command": "local-history.copyRevisionPathWorkspace",
+                "title": "Local History: Copy Revision Path (Workspace)"
             }
         ],
         "menus": {
@@ -94,6 +102,18 @@
                 {
                     "command": "local-history.clearHistory",
                     "when": "editorIsOpen && resourceScheme == file"
+                },
+                {
+                    "command": "local-history.clearOldHistory",
+                    "when": "workspaceFolderCount"
+                },
+                {
+                    "command": "local-history.copyRevisionPath",
+                    "when": "editorIsOpen && resourceScheme == file"
+                },
+                {
+                    "command": "local-history.copyRevisionPathWorkspace",
+                    "when": "workspaceFolderCount"
                 }
             ],
             "editor/title": [
@@ -118,18 +138,33 @@
                     "command": "local-history.clearHistory",
                     "when": "editorTextFocus",
                     "group": "LocalHistory@2"
+                },
+                {
+                    "command": "local-history.copyRevisionPath",
+                    "when": "editorTextFocus",
+                    "group": "LocalHistory@3"
                 }
             ],
             "explorer/context": [
                 {
                     "command": "local-history.viewHistory",
-                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot",
+                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot && !listMultiSelection",
                     "group": "LocalHistory@1"
                 },
                 {
                     "command": "local-history.clearHistory",
-                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot",
+                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot && !listMultiSelection",
                     "group": "LocalHistory@2"
+                },
+                {
+                    "command": "local-history.copyRevisionPath",
+                    "when": "!explorerResourceIsFolder && !explorerResourceIsRoot && !listMultiSelection",
+                    "group": "LocalHistory@3"
+                },
+                {
+                    "command": "local-history.copyRevisionPathWorkspace",
+                    "when": "explorerResourceIsFolder && explorerResourceIsRoot && !listMultiSelection",
+                    "group": "LocalHistory@4"
                 }
             ],
             "view/title": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,8 @@ export function activate(context: vscode.ExtensionContext) {
     // Instantiate a new local history manager.
     const manager: LocalHistoryManager = new LocalHistoryManager();
 
+    // Command which displays the local history of the active file.
     disposable.push(
-        // Displays the local history of the active file.
         vscode.commands.registerCommand(Commands.VIEW_HISTORY, (uri: vscode.Uri) => {
             if (uri === undefined) {
                 uri = vscode.window.activeTextEditor!.document.uri;
@@ -104,6 +104,30 @@ export function activate(context: vscode.ExtensionContext) {
     disposable.push(vscode.commands.registerCommand(Commands.VIEW_DOCUMENTATION, () => {
         vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://github.com/vince-fugnitto/local-history-ext#documentation'));
     }));
+
+    // Command which writes the revision path of the active editor into the clipboard.
+    disposable.push(
+        vscode.commands.registerCommand(Commands.COPY_REVISION_PATH, (uri: vscode.Uri) => {
+            if (uri === undefined) {
+                uri = vscode.window.activeTextEditor!.document.uri;
+            }
+
+            manager.copyRevisionPath(uri);
+        })
+    );
+
+    // Command which writes the revision path of the given workspace into the clipboard.
+    disposable.push(
+        vscode.commands.registerCommand(Commands.COPY_REVISION_PATH_WORKSPACE, (uri: vscode.Uri) => {
+            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 0) {
+                return;
+            } else if (uri === undefined) {
+                uri = vscode.workspace.workspaceFolders![0].uri;
+            }
+
+            manager.copyRevisionPathWorkspace(uri);
+        })
+    );
 
     context.subscriptions.push(...disposable);
 

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -91,7 +91,7 @@ export class LocalHistoryManager {
                 }));
 
                 if (items.length === 0) {
-                    vscode.window.showInformationMessage(`No local history file found for '${path.basename(uri.fsPath)}'`);
+                    vscode.window.showInformationMessage(`No local history found for '${path.basename(uri.fsPath)}'`);
                     return;
                 }
 
@@ -267,7 +267,7 @@ export class LocalHistoryManager {
 
             // Check if local history exists for the active file
             if (!fs.existsSync(revisionFolderPath)) {
-                vscode.window.showInformationMessage(`No local history file found for '${path.basename(uri.fsPath)}'`);
+                vscode.window.showInformationMessage(`No local history found for '${path.basename(uri.fsPath)}'`);
                 return;
             }
 
@@ -395,12 +395,12 @@ export class LocalHistoryManager {
                             fs.unlinkSync(file);
                         }
                         this.removeEmptyFolders();
-                        vscode.window.showInformationMessage(`Successfully deleted ${fileUris.length} local-history file(s)`);
+                        vscode.window.showInformationMessage(`Successfully deleted ${fileUris.length} local-history file(s).`);
                         vscode.commands.executeCommand(Commands.TREE_REFRESH);
                     }
                 });
             } else {
-                vscode.window.showInformationMessage(`No local-history found older than ${days} day(s)`);
+                vscode.window.showInformationMessage(`No local-history found older than ${days} day(s).`);
             }
         }
         catch (err) {
@@ -484,4 +484,35 @@ export class LocalHistoryManager {
             }
         }
     }
+
+    /**
+     * Writes the revision path of the active editor into the clipboard.
+     */
+    public async copyRevisionPath(uri: vscode.Uri): Promise<void> {
+        if (uri) {
+            const revisionFolderPath = this.getRevisionFolderPath(uri.fsPath);
+
+            if (!fs.existsSync(revisionFolderPath)) {
+                vscode.window.showInformationMessage(`No revision folder found for '${path.basename(uri.fsPath)}'`);
+                return;
+            }
+
+            await vscode.env.clipboard.writeText(revisionFolderPath);
+        }
+    }
+
+    /**
+     * Writes the revision path of the given workspace into the clipboard.
+     */
+    public async copyRevisionPathWorkspace(uri: vscode.Uri): Promise<void> {
+        const revisionFolderPath = this.getRevisionFolderPath(uri.fsPath);
+
+        if (!fs.existsSync(revisionFolderPath)) {
+            vscode.window.showInformationMessage('No revision folder found for the current workspace.');
+            return;
+        }
+
+        await vscode.env.clipboard.writeText(revisionFolderPath);
+    }
+
 }

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -95,6 +95,8 @@ export namespace Commands {
     export const CLEAR_HISTORY = 'local-history.clearHistory';
     export const CLEAR_OLD_HISTORY = 'local-history.clearOldHistory';
     export const REMOVE_REVISION = 'local-history.removeRevision';
+    export const COPY_REVISION_PATH = 'local-history.copyRevisionPath';
+    export const COPY_REVISION_PATH_WORKSPACE = 'local-history.copyRevisionPathWorkspace';
     export const REVERT_TO_PREVIOUS_REVISION = 'local-history.revertToPrevRevision';
     export const TREE_DIFF = 'extension.openRevisionInDiff';
     export const TREE_REFRESH = 'local-history.refreshEntry';


### PR DESCRIPTION
**Description**
- Add two new commands which end-users can use to easily locate their revisions:
1. copy revision path: adds the revision path (active editor) to the clipboard
2. copy revision path (workspace): adds the revision path (the given workspace) to the clipboard
- Update when-context for `View History` and `Clear History` commands

**How to test**
1. Make sure your clipboard does not have old revision path
2. Right-click on a file that has revisions and select `Copy Revision Path` (Should see the file's revision path when you paste it)
3. Select multiple files and right-click (**Should not see `Copy Revision Path`, `View History`, `Clear History`**)
4. Select 1 or no item in the explorer and right-click on the empty space below (**Should see `Copy Revision Path (Workspace)`**):
![image](https://user-images.githubusercontent.com/23107734/83445311-bfab4900-a41a-11ea-93d9-409b9bf0e746.png)
5. Select multiple items in the explorer and right-click on the empty space (**Should not see `Copy Revision Path (Workspace)`**)
6. Add a second root folder to the workspace, select the two workspace folder and right-click on the empty space (**Should not see `Copy Revision Path (Workspace)`**)


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>