### PR TITLE
Preference: set the path of .local-history folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
                     "type": "number",
                     "default": 30,
                     "minimum": 1,
-                    "description": "Controls the maximum number of saved revisions allowed for a given file"
+                    "description": "Controls the maximum number of saved revisions allowed for a given file."
                 },
                 "local-history.excludeFiles": {
                     "type": "object",
@@ -178,6 +178,10 @@
                         "**/.local-history/**": true
                     },
                     "scope": "resource"
+                },
+                "local-history.historyPath": {
+                    "type": "string",
+                    "description": "Controls the path of .local-history folder in the OS."
                 }
             }
         }

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -347,7 +347,7 @@ export class LocalHistoryManager {
      */
     public getRevisionFolderPath(activeEditorUri: string): string {
         const editorUri = activeEditorUri.replace(/[\:/]/g, path.sep);
-        const historyFolderPath = path.normalize(path.join(os.homedir(), LOCAL_HISTORY_DIRNAME));
+        const historyFolderPath = this.localHistoryPreferencesService.historyPath;
         const revisionFolderPath = path.normalize(path.join(historyFolderPath, editorUri));
 
         return revisionFolderPath;
@@ -369,7 +369,7 @@ export class LocalHistoryManager {
      * @param days The number of days.
      */
     public removeOldFiles(days: number): void {
-        const dirPath = path.join(os.homedir(), LOCAL_HISTORY_DIRNAME);
+        const dirPath = this.localHistoryPreferencesService.historyPath;
         if (!fs.existsSync(dirPath)) {
             return;
         }
@@ -378,7 +378,7 @@ export class LocalHistoryManager {
             const currentDate = Date.now();
             const fileUris: string[] = [];
             for (const folder of folders) {
-                const revisionFolderPath = path.join(os.homedir(), LOCAL_HISTORY_DIRNAME, folder);
+                const revisionFolderPath = path.join(this.localHistoryPreferencesService.historyPath, folder);
                 const files = fs.readdirSync(revisionFolderPath);
                 files.filter((file) => {
                     const filePath = path.join(revisionFolderPath, file);
@@ -475,7 +475,7 @@ export class LocalHistoryManager {
      * Removes empty folders.
      */
     private removeEmptyFolders() {
-        const localHistoryDir = path.normalize(path.join(os.homedir(), LOCAL_HISTORY_DIRNAME));
+        const localHistoryDir = this.localHistoryPreferencesService.historyPath;
         const folders = fs.readdirSync(localHistoryDir);
         for (const folder of folders) {
             const folderPath = path.normalize(path.join(localHistoryDir, folder));

--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -6,6 +6,7 @@ export class LocalHistoryPreferencesService {
     private _excludedFiles: object = Preferences.EXCLUDE_FILES.default;
     private _fileLimit: number = Preferences.FILE_LIMIT.default;
     private _fileSizeLimit: number = Preferences.FILE_SIZE_LIMIT.default;
+    private _historyPath: string = Preferences.HISTORY_PATH.default;
     private _maxEntriesPerFile: number = Preferences.MAX_ENTRIES_PER_FILE.default;
     private _saveDelay: number = Preferences.SAVE_DELAY.default;
 
@@ -13,6 +14,7 @@ export class LocalHistoryPreferencesService {
         this.excludedFiles = this.getExcludedFiles();
         this.fileLimit = this.getFileLimit();
         this.fileSizeLimit = this.getFileSizeLimit();
+        this.historyPath = this.getHistoryPath();
         this.maxEntriesPerFile = this.getMaxEntriesPerFile();
         this.saveDelay = this.getSaveDelay();
 
@@ -26,6 +28,10 @@ export class LocalHistoryPreferencesService {
             }
             if (event.affectsConfiguration(Preferences.FILE_SIZE_LIMIT.id)) {
                 this.fileSizeLimit = this.getFileSizeLimit();
+            }
+            if (event.affectsConfiguration(Preferences.HISTORY_PATH.id)) {
+                this.historyPath = this.getHistoryPath();
+                vscode.window.showInformationMessage('Path for .local-history folder updated. Please move the content inside the old .local-history folder manually.');
             }
             if (event.affectsConfiguration(Preferences.MAX_ENTRIES_PER_FILE.id)) {
                 this.maxEntriesPerFile = this.getMaxEntriesPerFile();
@@ -85,6 +91,22 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
+     * Get the path of .local-history folder in the OS.
+     * @returns the path of .local-history folder in the OS.
+     */
+    get historyPath(): string {
+        return this._historyPath;
+    }
+
+    /**
+     * Set the path of .local-history folder in the OS.
+     * @param path the path of .local-history folder in the OS.
+     */
+    set historyPath(path: string) {
+        this._historyPath = path;
+    }
+
+    /**
      * Get the maximum allowed entries for a file.
      * @returns the maximum allowed entries for a file.
      */
@@ -126,7 +148,7 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
-     * Get the configuration value for 'EXCLUDE_FILES'
+     * Get the configuration value for 'EXCLUDE_FILES'.
      */
     private getExcludedFiles(): object {
         const value = this.getPreferenceValueById(Preferences.EXCLUDE_FILES.id);
@@ -135,8 +157,7 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
-     * Get the configuration value for 'FILE_LIMIT'
-     *
+     * Get the configuration value for 'FILE_LIMIT'.
      */
     private getFileLimit(): number {
         const value = this.getPreferenceValueById(Preferences.FILE_LIMIT.id);
@@ -144,11 +165,20 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
-     * Get the configuration value for 'FILE_SIZE_LIMIT'
+     * Get the configuration value for 'FILE_SIZE_LIMIT'.
      */
     private getFileSizeLimit(): number {
         const value = this.getPreferenceValueById(Preferences.FILE_SIZE_LIMIT.id);
         return typeof value === 'number' ? value : Preferences.FILE_SIZE_LIMIT.default as number;
+    }
+
+    /**
+     * Get the configuration value for 'HISTORY_PATH'.
+     */
+    private getHistoryPath(): string {
+        const value = this.getPreferenceValueById(Preferences.HISTORY_PATH.id);
+        const newValue = typeof value === 'string' && value.length ? value : Preferences.HISTORY_PATH.default as string;
+        return newValue;
     }
 
     /**

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -1,3 +1,6 @@
+import * as os from 'os';
+import * as path from 'path';
+
 /**
  * The number of milliseconds in a day.
  */
@@ -68,6 +71,14 @@ export namespace Preferences {
     export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
         id: 'local-history.fileSizeLimit',
         default: 25
+    };
+
+    /**
+     * Controls the path of .local-history folder in the OS.
+     */
+    export const HISTORY_PATH: LocalHistoryPreference = {
+        id: 'local-history.historyPath',
+        default: path.normalize(path.join(os.homedir(), LOCAL_HISTORY_DIRNAME))
     };
 
     /**


### PR DESCRIPTION
**Description**
- add a preference that allows the user to set the path of the .local-history folder

**How to test**
1. Make changes to a file inside a workspace
2. Check to make sure that a revision is created in user's home
3. Go to Preferences > Settings > Search for `Local History`
4. Change the preference value of `history path` by adding an absolute path (**should see a message that asks user to move files in .local-history manually**)
5. Make changes to a file in the workspace again (**should see a revision created in the new `history-path` location** )

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>