### PR TITLE
Prevent user from violating the min/max values

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,22 +188,25 @@
                 "local-history.maxEntriesPerFile": {
                     "type": "number",
                     "default": 10,
+                    "minimum": 3,
                     "description": "Controls the number of entries to keep for a given file."
                 },
                 "local-history.saveDelay": {
                     "type": "number",
-                    "default": 5000,
+                    "default": 300000,
+                    "minimum": 0,
                     "description": "Controls the save delay in milliseconds."
                 },
                 "local-history.fileSizeLimit": {
                     "type": "number",
-                    "default": 25,
+                    "default": 5,
+                    "minimum": 0.5,
                     "description": "Controls the maximum acceptable file size for storing revisions in megabytes."
                 },
                 "local-history.fileLimit": {
                     "type": "number",
                     "default": 30,
-                    "minimum": 1,
+                    "minimum": 5,
                     "description": "Controls the maximum number of saved revisions allowed for a given file"
                 },
                 "local-history.excludeFiles": {

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -67,7 +67,7 @@ export namespace Preferences {
      */
     export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
         id: 'local-history.fileSizeLimit',
-        default: 25
+        default: 5
     };
 
     /**
@@ -83,7 +83,7 @@ export namespace Preferences {
      */
     export const SAVE_DELAY: LocalHistoryPreference = {
         id: 'local-history.saveDelay',
-        default: 5000
+        default: 300000
     };
 
 }


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/72

Added minimum values on the preferences, so that the user doesn't violate
the behavior of the preference. If the value plugged is less than the
min, it will use the default value.

**How to test**
- Try setting the values of preferences lower than the minimum, and check to see if they reset back to default or not 



Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>