### PR TITLE
Updates file content when saved within the save delay

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -161,6 +161,10 @@ export class LocalHistoryManager {
                         return;
                     }
                 }
+                else if (activeDocumentContent === mostRecentRevisionContent) {
+                    fs.renameSync(mostRecentRevision, historyFilePath);
+                    return;
+                }
                 else {
                     fs.renameSync(mostRecentRevision, historyFilePath);
                     await this.writeFile(historyFilePath, activeDocumentContent, true);
@@ -227,17 +231,17 @@ export class LocalHistoryManager {
      * @param isReadonly: controls whether to modify the file as 'readonly'.
      */
     private async writeFile(uri: string | vscode.Uri, content: string, isReadonly: boolean): Promise<void> {
+        if (fs.existsSync(typeof uri === 'string' ? uri : uri.fsPath)) {
+            // Changes the file permission to 'WRITE'. 
+            this.modifyFilePermissions(uri, '200');
+        }
         const fileUri: vscode.Uri = typeof uri === 'string' ? vscode.Uri.file(uri) : uri;
         const encodedContent = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(fileUri, encodedContent);
 
         if (isReadonly) {
             // Change file permission to read-only.
-            fs.chmod(typeof uri === 'string' ? uri : uri.fsPath, 0o400, (err) => {
-                if (err) {
-                    OutputManager.appendWarningMessage(err.message);
-                }
-            });
+            this.modifyFilePermissions(uri, '400');
         }
     }
 
@@ -528,6 +532,19 @@ export class LocalHistoryManager {
         }
 
         await vscode.env.clipboard.writeText(revisionFolderPath);
+    }
+
+    /**
+     * Modifies the permission of a file. 
+     * @param uri the path of source file. 
+     * @param filePermissions File mode for modifying permissions. 
+     */
+    private modifyFilePermissions(uri: string | vscode.Uri, filePermissions: string) {
+        fs.chmod(typeof uri === 'string' ? uri : uri.fsPath, filePermissions, (err) => {
+            if (err) {
+                OutputManager.appendWarningMessage(err.message);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/114

Saves the content of the file when it is within the save delay timer.

**How to Test:**
1. Open a folder in workspace.
2. Create a revision.
3. Save without making any changes.
4. Save a file within the `saveDelay` timer.
5. Check to see if there is an error logged. 
6. Check to see if the revision is readonly.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>