### PR TITLE
tree-view: update user-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
     ],
     "main": "./out/extension.js",
     "contributes": {
-        "viewsWelcome": [
-            {
-                "view": "localHistoryTree",
-                "contents": "No local history found."
-            }
-        ],
         "viewsContainers": {
             "activitybar": [
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,10 +132,24 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(...disposable);
 
-    // Tree View
-    const treeProvider = new LocalHistoryTreeProvider(manager);
-    vscode.window.registerTreeDataProvider('localHistoryTree', treeProvider);
-    vscode.commands.registerCommand(Commands.TREE_REFRESH, () => treeProvider.refresh());
+    // Local History Tree View.
+    const treeDataProvider = new LocalHistoryTreeProvider(manager);
+    const treeView = vscode.window.createTreeView('localHistoryTree', {
+        treeDataProvider,
+        canSelectMany: false,
+        showCollapseAll: false
+    });
+
+    // Update the message.
+    treeView.message = treeDataProvider.getTreeViewMessage();
+    treeDataProvider.onDidChangeTreeData(() => {
+        treeView.message = treeDataProvider.getTreeViewMessage();
+    });
+    vscode.window.onDidChangeActiveTextEditor(() => {
+        treeView.message = treeDataProvider.getTreeViewMessage();
+    });
+
+    vscode.commands.registerCommand(Commands.TREE_REFRESH, () => treeDataProvider.refresh());
     vscode.commands.registerCommand(Commands.TREE_DIFF, uri =>
         manager.displayDiff(vscode.Uri.file(uri), vscode.window.activeTextEditor!.document.uri));
 }


### PR DESCRIPTION
**Description**

The following commit updates the 'local-history tree view' to include the following:
- adds the `iconPath` to the tree-view entries
- adds the `message` to the view displaying the active editor for clarity

_Active Editor with Results_:

<div align='left'>

<img width="400" alt="Screen Shot 2020-06-05 at 4 26 16 PM" src="https://user-images.githubusercontent.com/40359487/83919902-9d326c00-a749-11ea-9538-d1da19916e3f.png">

</div>

_Active Editor without Results_:

<div align='left'>

<img width="400" alt="Screen Shot 2020-06-05 at 4 26 28 PM" src="https://user-images.githubusercontent.com/40359487/83919913-a1f72000-a749-11ea-88e5-510f5337b209.png">

</div>

_No Active Editor_:

<div align='left'>

<img width="400" alt="Screen Shot 2020-06-05 at 4 26 38 PM" src="https://user-images.githubusercontent.com/40359487/83919934-acb1b500-a749-11ea-8268-e627758090a3.png">

</div>

---

_Note_: I wanted to add the revision count to the `message` but there are issues with it being asynchronous to get the value.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>