### PR TITLE
Small bug fixes

### DIFF
--- a/src/local-history/local-history-tree-provider.ts
+++ b/src/local-history/local-history-tree-provider.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as moment from 'moment';
 // eslint-disable-next-line no-unused-vars
 import { LocalHistoryManager } from './local-history-manager';
+import { OutputManager } from './local-history-output-manager';
 
 export class Revision extends vscode.TreeItem {
     uri: string;
@@ -86,7 +87,7 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
         try {
             revisionsExist = fs.readdirSync(this.manager.getRevisionFolderPath(editor.document.fileName)).length !== 0;
         } catch (e) {
-            console.error(`message: ${e}`);
+            OutputManager.appendWarningMessage(['An error has occurred when updating the tree view message', e]);
         }
         const basename = path.basename(editor.document.fileName);
         return revisionsExist ? basename : `No history found for '${basename}'.`;


### PR DESCRIPTION
**Description**
- fix the error that occurs when viewing the history for an active editor with no revisions
- prevent a revision from being created when the active editor has no content
- fix `statSync` error in `checkPermission`
- Use `OutputChannel` to display error for tree-view message

**How to test**
1. Create a new file in a workspace (**keep it blank**) and save (**no revision is created**)
2.  View history for the active editor (**should no longer see an error in the output channel**)

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>