### PR TITLE
Remove empty folders when revision removed from UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,6 +452,29 @@
 				"object-keys": "^1.0.12"
 			}
 		},
+		"delete-empty": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/delete-empty/-/delete-empty-3.0.0.tgz",
+			"integrity": "sha512-ZUyiwo76W+DYnKsL3Kim6M/UOavPdBJgDYWOmuQhYaZvJH0AXAHbUNyEDtRbBra8wqqr686+63/0azfEk1ebUQ==",
+			"requires": {
+				"ansi-colors": "^4.1.0",
+				"minimist": "^1.2.0",
+				"path-starts-with": "^2.0.0",
+				"rimraf": "^2.6.2"
+			},
+			"dependencies": {
+				"ansi-colors": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				}
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -804,8 +827,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -829,7 +851,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -962,7 +983,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -971,8 +991,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
 			"version": "7.1.0",
@@ -1370,7 +1389,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -1446,8 +1464,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -1460,6 +1477,11 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"path-starts-with": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-2.0.0.tgz",
+			"integrity": "sha512-3UHTHbJz5+NLkPafFR+2ycJOjoc4WV2e9qCZCnm71zHiWaFrm1XniLVTkZXvaRgxr1xFh9JsTdicpH2yM03nLA=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -1526,7 +1548,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -1883,8 +1904,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
         "vscode-test": "^1.2.2"
     },
     "dependencies": {
+        "delete-empty": "^3.0.0",
         "minimatch": "^3.0.4",
         "moment": "2.24.0"
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,14 +45,14 @@ export function activate(context: vscode.ExtensionContext) {
                 // Diff is opened, click 'Remove revision' either from diff toolbar or tree-view
                 vscode.window.showWarningMessage(`Are you sure you want to permanently delete '${path.basename(editors[0].document.fileName)}'?`, { modal: true }, 'Delete').then((selection) => {
                     if (selection === 'Delete') {
-                        manager.removeRevision(editors[0].document.uri, true);
+                        manager.removeRevision(editors[0].document.uri, editors[1].document.uri, true);
                     }
                 });
             } else if (revision) {
                 // No diff opened, click 'Remove revision' from tree-view
                 vscode.window.showWarningMessage(`Are you sure you want to permanently delete '${path.basename(revision.uri)}'?`, { modal: true }, 'Delete').then((selection) => {
                     if (selection === 'Delete') {
-                        manager.removeRevision(vscode.Uri.file(revision.uri));
+                        manager.removeRevision(vscode.Uri.file(revision.uri), vscode.window.activeTextEditor!.document.uri);
                     }
                 });
             }
@@ -73,7 +73,6 @@ export function activate(context: vscode.ExtensionContext) {
     disposable.push(
         vscode.commands.registerCommand(Commands.CLEAR_OLD_HISTORY, async () => {
             const days = await vscode.window.showInputBox({
-                value: '30',
                 placeHolder: 'Please enter the amount of days',
                 validateInput: input => {
                     const day = parseInt(input);

--- a/src/local-history/local-history.d.ts
+++ b/src/local-history/local-history.d.ts
@@ -1,0 +1,1 @@
+declare module 'delete-empty';


### PR DESCRIPTION
- Remove the empty folders in a workspace revision dir recursively when:
1. we manually remove the last revision (either from the tree or diff editor menu) for an active editor
2. we clear all revisions for an active editor

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>