### PR TITLE
refresh tree view when revisions created

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -16,8 +16,8 @@ export class LocalHistoryManager {
     private localHistoryPreferencesService: LocalHistoryPreferencesService = new LocalHistoryPreferencesService();
 
     constructor() {
-        vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-            this.saveEditorContext(document);
+        vscode.workspace.onDidSaveTextDocument(async (document: vscode.TextDocument) => {
+            await this.saveEditorContext(document);
             vscode.commands.executeCommand(Commands.TREE_REFRESH);
         });
 


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/122

Refreshes the tree-view when a new revision is created.
![02](https://user-images.githubusercontent.com/43870550/83996570-7c753c80-a92a-11ea-8403-18d47646bcae.png)


**How to Test:**
1. Open workspace
2. Open a file as an active editor, toggle to the Local History Tree View tab
3. Create a new revision, check to see if the new revision shows up in the tree-view

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>