### PR TITLE
[bug] View History command doesn't work

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -46,12 +46,14 @@ export class LocalHistoryManager {
         this._historyFilesForActiveEditor = [];
 
         try {
-            for (const [fileName, type] of await vscode.workspace.fs.readDirectory(vscode.Uri.file(revisionFolderPath))) {
-                if (type === vscode.FileType.File) {
+            const files = fs.readdirSync(revisionFolderPath);
+            for (const file of files) {
+                const filePath = path.join(revisionFolderPath, file);
+                if (fs.statSync(filePath).isFile()) {
                     const data: HistoryFileProperties = {
-                        fileName: fileName,
-                        timestamp: this.parseTimestamp(fileName),
-                        uri: path.join(revisionFolderPath, fileName),
+                        fileName: file,
+                        timestamp: this.parseTimestamp(file),
+                        uri: path.join(revisionFolderPath, file),
                     };
                     this._historyFilesForActiveEditor.unshift(data);
                 }


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/126

Updated the code to use node fs api for reading directories.
![theia](https://user-images.githubusercontent.com/43870550/84112045-0938fc80-a9f6-11ea-8d1f-e44ead774f72.png)

**How to test:**
1. Run theia with the extension
2. Make changes to a file
3. Run the command by `f1` `Local History: View Revisions`
4. Check to see if the revisions are displayed.


Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>