### PR TITLE
electron: fix local-history creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,6 +1104,11 @@
 				}
 			}
 		},
+		"interpret": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+		},
 		"is-buffer": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -1475,8 +1480,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-starts-with": {
 			"version": "2.0.0",
@@ -1501,6 +1505,14 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
 		"regexpp": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
@@ -1523,7 +1535,6 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -1602,6 +1613,16 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
+		},
+		"shelljs": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "dependencies": {
         "delete-empty": "^3.0.0",
         "minimatch": "^3.0.4",
-        "moment": "2.24.0"
+        "moment": "2.24.0",
+        "shelljs": "^0.8.4"
     }
 }

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -7,9 +7,9 @@ import * as moment from 'moment';
 import * as minimatch from 'minimatch';
 import { TextDecoder, TextEncoder } from 'util';
 import * as deleteEmpty from 'delete-empty';
-
 import { HistoryFileProperties, LOCAL_HISTORY_DIRNAME, DAY_TO_MILLISECONDS, Commands } from './local-history-types';
 import { OutputManager } from './local-history-output-manager';
+import * as shelljs from 'shelljs';
 
 export class LocalHistoryManager {
 
@@ -142,7 +142,7 @@ export class LocalHistoryManager {
         }
 
         const activeDocumentContent: string = await this.readFile(document.fileName);
-        
+
         if (activeDocumentContent.length === 0) {
             return;
         }
@@ -158,7 +158,7 @@ export class LocalHistoryManager {
 
         // Create a folder (and all the parent folders) for storing all the local history file for the active editor.
         if (!fs.existsSync(revisionFolderPath)) {
-            fs.mkdirSync(revisionFolderPath, { recursive: true });
+            shelljs.mkdir('-p', revisionFolderPath);
         }
 
         try {

--- a/src/local-history/local-history.d.ts
+++ b/src/local-history/local-history.d.ts
@@ -1,1 +1,2 @@
 declare module 'delete-empty';
+declare module 'shelljs';


### PR DESCRIPTION
**Description**

Fixes #125 

The following pull-request fixes the creation of the `.local-history` folder for the electron target (theia), which was caused by the following line which did not work in the version we have:

```ts
fs.mkdirSync(revisionFolderPath, { recursive: true });
```

Instead, we use `shelljs` which has the capability to create a folder structure given the full path.

**Steps to Reproduce**

1. package the extension (`vsce package`)
2. remove the local-history folder if it exists (`rm -rf ~/.local-history`)
3. add the extension to theia (electron) and test if the revisions are created
4. test the extension with theia (browser) to confirm there are no regressions

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>