### PR TITLE
Add revert to tree-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
                 "icon": {
                     "dark": "resources/dark/history.svg",
                     "light": "resources/light/history.svg"
-                },
-                "when": "textCompareEditorVisible && isInDiffEditor"
+                }
             },
             {
                 "command": "local-history.removeRevision",
@@ -119,18 +118,6 @@
                     "when": "workspaceFolderCount"
                 }
             ],
-            "editor/title": [
-                {
-                    "command": "local-history.revertToPrevRevision",
-                    "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "local-history.removeRevision",
-                    "when": "textCompareEditorVisible && isInDiffEditor && !multipleEditorGroups",
-                    "group": "navigation@2"
-                }
-            ],
             "editor/context": [
                 {
                     "command": "local-history.viewHistory",
@@ -179,9 +166,14 @@
             ],
             "view/item/context": [
                 {
+                    "command": "local-history.revertToPrevRevision",
+                    "when": "view == localHistoryTree && viewItem == local-history",
+                    "group": "inline@1"
+                },
+                {
                     "command": "local-history.removeRevision",
-                    "when": "view == localHistoryTree",
-                    "group": "inline"
+                    "when": "view == localHistoryTree && viewItem == local-history",
+                    "group": "inline@2"
                 }
             ]
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,17 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    // Command which reverts the active editor to its previous revision.
+    // Command which reverts the active editor to one of its previous revisions.
     disposable.push(
-        vscode.commands.registerTextEditorCommand(Commands.REVERT_TO_PREVIOUS_REVISION, () => {
-            const editors = vscode.window.visibleTextEditors;
-            if (editors && editors.length === 2) {
-                vscode.window.showWarningMessage(`Are you sure you want to revert '${path.basename(editors[1].document.fileName)}' to its previous state?`, { modal: true }, 'Revert').then((selection) => {
-                    if (selection === 'Revert') {
-                        manager.revertToPrevRevision(editors[0], editors[1]);
-                        vscode.commands.executeCommand(Commands.TREE_REFRESH);
-                    }
-                });
+        vscode.commands.registerCommand(Commands.REVERT_TO_PREVIOUS_REVISION, (revision) => {
+            if (revision) {
+                manager.revertToPrevRevision(vscode.Uri.file(revision.uri));
             }
         })
     );

--- a/src/local-history/local-history-tree-provider.ts
+++ b/src/local-history/local-history-tree-provider.ts
@@ -15,6 +15,7 @@ export class Revision extends vscode.TreeItem {
         this.uri = uri;
         this.command = command;
         this.iconPath = vscode.ThemeIcon.File;
+        this.contextValue = 'local-history';
     }
 
     get tooltip(): string {


### PR DESCRIPTION
**Description**
- Add `revert to previous revision` to local-history tree-view context-menu
- Remove `delete` and `revert` from diff editor toolbar

**How to test**
1. Create 2 revisions
2. Go to local-history tree-view and click the `revert` icon (**without opening the diff**; should see a `_r` revision being created)
3. Open a diff and click `revert` (should see a `_r` revision being created)
4. Pin a diff, then open another diff and click `revert` (current editor should be reverted to the highlighted revision)
![image](https://user-images.githubusercontent.com/23107734/84204705-b2750680-aa79-11ea-8b7a-7292add8b25e.png)


Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>