### PR TITLE
Remove functionality for updating filename on non-dirty save

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -175,7 +175,6 @@ export class LocalHistoryManager {
                     }
                 }
                 else if (activeDocumentContent === mostRecentRevisionContent) {
-                    fs.renameSync(mostRecentRevision, historyFilePath);
                     return;
                 }
                 else {


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/134

Removes the functionality for renaming the file when the file content is
not changed.

How to test: 
1. Create a revision
2. Save without any changes (desired behavior: no changes should be made in theia)

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>