### PR TITLE
tree-view: fix message

### DIFF
--- a/src/local-history/local-history-tree-provider.ts
+++ b/src/local-history/local-history-tree-provider.ts
@@ -80,7 +80,7 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
      */
     getTreeViewMessage(): string {
         const editor = vscode.window.activeTextEditor;
-        if (!editor) {
+        if (!editor || editor?.document.uri.scheme !== 'file') {
             return 'No active editor opened.';
         }
         let revisionsExist: boolean = false;


### PR DESCRIPTION
**Description**

Fixes #137 

The following commit fixes the `tree-view` message to only reflect actual active text documents which have a `file` scheme. 

For example, when the output-view channel is opened, it should not reflect so in the tree-view anymore.

**Steps to Reproduce**

1. open an editor and make a revision
2. open the `tree-view` it should show the active editor
3. close the active editor
4. open the `local history` output channel, the tree-view should not display the output-channel as the active editor
5. there should be no error logs in the output channel

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>