### PR TITLE
cleanup: remove 'max entries per file'

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,12 +180,6 @@
         "configuration": {
             "title": "Local History",
             "properties": {
-                "local-history.maxEntriesPerFile": {
-                    "type": "number",
-                    "default": 10,
-                    "minimum": 3,
-                    "description": "Controls the number of entries to keep for a given file."
-                },
                 "local-history.saveDelay": {
                     "type": "number",
                     "default": 300000,

--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -91,7 +91,7 @@ export class LocalHistoryManager {
             const revisionFolderPath = this.getRevisionFolderPath(uri.fsPath);
 
             this.loadHistory(revisionFolderPath).then(() => {
-                let items: vscode.QuickPickItem[] = this._historyFilesForActiveEditor.map(item => ({
+                const items: vscode.QuickPickItem[] = this._historyFilesForActiveEditor.map(item => ({
                     label: `$(calendar) ${item.timestamp}`,
                     description: path.basename(item.uri),
                     detail: `Last modified ${moment(item.timestamp.replace(/[-: ]/g, ''), 'YYYYMMDDhhmmss').fromNow()}`
@@ -102,8 +102,6 @@ export class LocalHistoryManager {
                     return;
                 }
 
-                // Limits the number of entries based on the preference 'local-history.maxEntriesPerFile`.
-                items = items.slice(0, this.localHistoryPreferencesService.maxEntriesPerFile);
                 vscode.window.showQuickPick(items,
                     {
                         placeHolder: `Please select a local history revision for '${path.basename(uri.fsPath)}'`,

--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -6,14 +6,12 @@ export class LocalHistoryPreferencesService {
     private _excludedFiles: object = Preferences.EXCLUDE_FILES.default;
     private _fileLimit: number = Preferences.FILE_LIMIT.default;
     private _fileSizeLimit: number = Preferences.FILE_SIZE_LIMIT.default;
-    private _maxEntriesPerFile: number = Preferences.MAX_ENTRIES_PER_FILE.default;
     private _saveDelay: number = Preferences.SAVE_DELAY.default;
 
     constructor() {
         this.excludedFiles = this.getExcludedFiles();
         this.fileLimit = this.getFileLimit();
         this.fileSizeLimit = this.getFileSizeLimit();
-        this.maxEntriesPerFile = this.getMaxEntriesPerFile();
         this.saveDelay = this.getSaveDelay();
 
         // Listen to changes to the preferences configuration and update accordingly.
@@ -26,9 +24,6 @@ export class LocalHistoryPreferencesService {
             }
             if (event.affectsConfiguration(Preferences.FILE_SIZE_LIMIT.id)) {
                 this.fileSizeLimit = this.getFileSizeLimit();
-            }
-            if (event.affectsConfiguration(Preferences.MAX_ENTRIES_PER_FILE.id)) {
-                this.maxEntriesPerFile = this.getMaxEntriesPerFile();
             }
             if (event.affectsConfiguration(Preferences.SAVE_DELAY.id)) {
                 this.saveDelay = this.getSaveDelay();
@@ -85,22 +80,6 @@ export class LocalHistoryPreferencesService {
     }
 
     /**
-     * Get the maximum allowed entries for a file.
-     * @returns the maximum allowed entries for a file.
-     */
-    get maxEntriesPerFile(): number {
-        return this._maxEntriesPerFile;
-    }
-
-    /**
-     * Set the maximum allowed entries for a file.
-     * @param max the maximum allowed entries for a file.
-     */
-    set maxEntriesPerFile(max: number) {
-        this._maxEntriesPerFile = max;
-    }
-
-    /**
      * Get the save delay in milliseconds.
      * @returns the save delay in milliseconds.
      */
@@ -149,14 +128,6 @@ export class LocalHistoryPreferencesService {
     private getFileSizeLimit(): number {
         const value = this.getPreferenceValueById(Preferences.FILE_SIZE_LIMIT.id);
         return typeof value === 'number' ? value : Preferences.FILE_SIZE_LIMIT.default as number;
-    }
-
-    /**
-     * Get the configuration value for `MAX_ENTRIES_PER_FILE`.
-     */
-    private getMaxEntriesPerFile(): number {
-        const value = this.getPreferenceValueById(Preferences.MAX_ENTRIES_PER_FILE.id);
-        return typeof value === 'number' ? value : Preferences.MAX_ENTRIES_PER_FILE.default as number;
     }
 
     /**

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -71,14 +71,6 @@ export namespace Preferences {
     };
 
     /**
-     * Controls the number of entries allowed for a given resource for display purposes.
-     */
-    export const MAX_ENTRIES_PER_FILE: LocalHistoryPreference = {
-        id: 'local-history.maxEntriesPerFile',
-        default: 10
-    };
-
-    /**
      * Controls the saving behavior when creating local-history revisions.
      */
     export const SAVE_DELAY: LocalHistoryPreference = {

--- a/src/test/suite/local-history-preference-service.test.ts
+++ b/src/test/suite/local-history-preference-service.test.ts
@@ -14,7 +14,6 @@ mocha.suite('LocalHistoryPreferencesService', () => {
     });
 
     mocha.afterEach(async () => {
-        service.maxEntriesPerFile = Preferences.MAX_ENTRIES_PER_FILE.default;
         service.saveDelay = Preferences.SAVE_DELAY.default;
     });
 
@@ -37,17 +36,6 @@ mocha.suite('LocalHistoryPreferencesService', () => {
             const updatedValue: number = 10;
             service.fileSizeLimit = updatedValue;
             assert.equal(service.fileSizeLimit, updatedValue);
-        });
-    });
-
-    mocha.describe(`Preference: '${Preferences.MAX_ENTRIES_PER_FILE.id}'`, () => {
-        mocha.it('should return the correct default value', () => {
-            assert.equal(service.maxEntriesPerFile, Preferences.MAX_ENTRIES_PER_FILE.default);
-        });
-        mocha.it('should properly update the value', () => {
-            const updatedValue: number = 100;
-            service.maxEntriesPerFile = updatedValue;
-            assert.equal(service.maxEntriesPerFile, updatedValue);
         });
     });
 
@@ -89,9 +77,6 @@ mocha.suite('LocalHistoryPreferencesService', () => {
         });
         mocha.it(`should properly return the '${Preferences.FILE_SIZE_LIMIT.id}' preference`, () => {
             assert.equal(service['getPreferenceValueById'](Preferences.FILE_SIZE_LIMIT.id), Preferences.FILE_SIZE_LIMIT.default);
-        });
-        mocha.it(`should properly return the '${Preferences.MAX_ENTRIES_PER_FILE.id}' preference`, () => {
-            assert.equal(service['getPreferenceValueById'](Preferences.MAX_ENTRIES_PER_FILE.id), Preferences.MAX_ENTRIES_PER_FILE.default);
         });
         mocha.it(`should properly return the '${Preferences.SAVE_DELAY.id}' preference`, () => {
             assert.equal(service['getPreferenceValueById'](Preferences.SAVE_DELAY.id), Preferences.SAVE_DELAY.default);


### PR DESCRIPTION
**Description**

The following pull-request removes the preference `maxEntriesPerFile`. The preference was only used to trim the list of entries when performing `View History` and is ultimately more confusing than anything for end-users. Instead, like the `tree-view` all revisions will be available to end-users to choose from.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>