### PR TITLE
Log when file exceeds the file-size limit

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -493,8 +493,9 @@ export class LocalHistoryManager {
     private fileSizeLimit(document: vscode.TextDocument): boolean {
         if (fs.existsSync(document.fileName)) {
             const sizeInBytes = fs.statSync(document.uri.fsPath).size;
-            const sizeInMegaBytes = sizeInBytes / 1000000;
+            const sizeInMegaBytes = sizeInBytes / 1048576;
             if (sizeInMegaBytes > this.localHistoryPreferencesService.fileSizeLimit) {
+                OutputManager.appendInfoMessage(`No new revisions created for file '${path.basename(document.fileName)}'. The file exceeds the local history file size limit (${this.localHistoryPreferencesService.fileSizeLimit}Mb).`);
                 return false;
             }
             return true;

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -81,7 +81,7 @@ export namespace Preferences {
     };
 
     /**
-     * Controls the maximum acceptable file size for storing revisions.
+     * Controls the maximum acceptable file size for storing revisions in megabytes.
      */
     export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
         id: 'local-history.fileSizeLimit',


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/152

Updated the conversion of bytes to megabytes based on base 2 conversion
(1mb = 1024 bytes)

Log when file size is exceeded than what is set in the preferences.

**How to test:**
1. Change the file size limit in the preferences to 2mb
2. [testing.txt](https://github.com/vince-fugnitto/local-history-ext/files/4782911/testing.txt) Add this file in your workspace, and try saving it 
3. Check to see if in the `Local History` Output channel, a new message is logged. 
4. Try saving a file within the file-size limit(saves without failing) 


Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>