### PR TITLE
docs: add outline to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 
 <img src='https://api.travis-ci.com/vince-fugnitto/local-history-ext.svg?branch=master' />
 
+- [Description](#description)
+- [Features](#features)
+- [Documentation](#documentation)
+  - [Commands](#commands)
+  - [Preferences](#preferences)
+- [Development](#development)
+- [License](#license)
+
 
 ## Description
 


### PR DESCRIPTION
Fixes: #156

The following adds an outline of anchor points (headers) of the readme
for easier and faster navigation of important sections.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>