### PR TITLE
Reset to default if the value of the preferences are set below min

### DIFF
--- a/src/local-history/local-history-preferences-service.ts
+++ b/src/local-history/local-history-preferences-service.ts
@@ -135,7 +135,7 @@ export class LocalHistoryPreferencesService {
      */
     private getFileLimit(): number {
         const value = this.getPreferenceValueById(Preferences.FILE_LIMIT.id);
-        return typeof value === 'number' ? value : Preferences.FILE_LIMIT.default as number;
+        return typeof value === 'number' && value >= Preferences.FILE_LIMIT.minimum ? value : Preferences.FILE_LIMIT.default as number;
     }
 
     /**
@@ -143,7 +143,7 @@ export class LocalHistoryPreferencesService {
      */
     private getFileSizeLimit(): number {
         const value = this.getPreferenceValueById(Preferences.FILE_SIZE_LIMIT.id);
-        return typeof value === 'number' ? value : Preferences.FILE_SIZE_LIMIT.default as number;
+        return typeof value === 'number' && value >= Preferences.FILE_SIZE_LIMIT.minimum ? value : Preferences.FILE_SIZE_LIMIT.default as number;
     }
 
     /**
@@ -151,6 +151,6 @@ export class LocalHistoryPreferencesService {
      */
     private getSaveDelay(): number {
         const value = this.getPreferenceValueById(Preferences.SAVE_DELAY.id);
-        return typeof value === 'number' ? value : Preferences.SAVE_DELAY.default as number;
+        return typeof value === 'number' && value >= Preferences.SAVE_DELAY.minimum ? value : Preferences.SAVE_DELAY.default as number;
     }
 }

--- a/src/local-history/local-history-types.ts
+++ b/src/local-history/local-history-types.ts
@@ -37,6 +37,10 @@ type LocalHistoryPreference = {
      * The default value for the preference.
      */
     default: any;
+    /**
+     * The minimum value for the preference.
+     */
+    minimum?: any;
 };
 
 /**
@@ -77,7 +81,8 @@ export namespace Preferences {
      */
     export const FILE_LIMIT: LocalHistoryPreference = {
         id: 'local-history.fileLimit',
-        default: 30
+        default: 30,
+        minimum: 5
     };
 
     /**
@@ -85,7 +90,8 @@ export namespace Preferences {
      */
     export const FILE_SIZE_LIMIT: LocalHistoryPreference = {
         id: 'local-history.fileSizeLimit',
-        default: 5
+        default: 5,
+        minimum: 0.5
     };
 
     /**
@@ -93,7 +99,8 @@ export namespace Preferences {
      */
     export const SAVE_DELAY: LocalHistoryPreference = {
         id: 'local-history.saveDelay',
-        default: 300000
+        default: 300000,
+        minimum: 0,
     };
 
 }


### PR DESCRIPTION
Fixes: https://github.com/vince-fugnitto/local-history-ext/issues/160

Any values of the preferences below the minimum if set, will be resetted
back to default.

**How to test:**
1. Set a preference value of file size limit to less than minimum
2. Use a file larger than the minimum and less than the default size
3. Check to see if the file is being saved or not(it should be saved - ideal use case)

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>