### PR TITLE
tree-view: improve handling of tree-view message

### DIFF
--- a/src/local-history/local-history-tree-provider.ts
+++ b/src/local-history/local-history-tree-provider.ts
@@ -102,7 +102,8 @@ export class LocalHistoryTreeProvider implements vscode.TreeDataProvider<Revisio
         }
         let revisionsExist: boolean = false;
         try {
-            revisionsExist = fs.readdirSync(this.manager.getRevisionFolderPath(editor.document.fileName)).length !== 0;
+            const revisionFolderPath = this.manager.getRevisionFolderPath(editor.document.fileName);
+            revisionsExist = fs.existsSync(revisionFolderPath) && fs.readdirSync(revisionFolderPath).length !== 0;
         } catch (e) {
             OutputManager.appendWarningMessage(['An error has occurred when updating the tree view message', e]);
         }


### PR DESCRIPTION
**Description**

Fixes #161 

The following pull-request updates the `tree-view` message logic to first verify if the directory exists before reading contents from it which lead to an error. The error was not harmful in any way (no reduced functionality) but the pull-request now handles it.

**Steps to Reproduce**

1. open an editor which does not contain any local-history
2. verify that the `tree-view` message is correct
3. verify that the `output channel` does not display any error messages regarding the `message`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>