### PR TITLE
save: omit saving for unmodified documents

### DIFF
--- a/src/local-history/local-history-manager.ts
+++ b/src/local-history/local-history-manager.ts
@@ -153,6 +153,12 @@ export class LocalHistoryManager {
      * Save the current context of the active editor.
      */
     public async saveEditorContext(document: vscode.TextDocument, isRevertChange?: boolean): Promise<void> {
+
+        // Skip creating revisions for documents which are not updated.
+        if (document.version === 1) {
+            return;
+        }
+
         if (!this.fileSizeLimit(document) || this.isFileExcluded(document)) {
             return;
         }


### PR DESCRIPTION
**Description**

Fixes: #162

The following pull-request updates the saving logic to omit creating revisions for unmodified files (as to not pollute the `.local-history`. 

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>